### PR TITLE
improved getPayload security

### DIFF
--- a/internal/mock/pkg/datastore.go
+++ b/internal/mock/pkg/datastore.go
@@ -114,7 +114,7 @@ func (mr *MockDatastoreMockRecorder) GetHeaderByPubkey(arg0, arg1, arg2 interfac
 }
 
 // GetPayload mocks base method.
-func (m *MockDatastore) GetPayload(arg0 context.Context, arg1 types.Hash) (*relay.BlockBidAndTrace, error) {
+func (m *MockDatastore) GetPayload(arg0 context.Context, arg1 relay.PayloadKey) (*relay.BlockBidAndTrace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPayload", arg0, arg1)
 	ret0, _ := ret[0].(*relay.BlockBidAndTrace)
@@ -172,7 +172,7 @@ func (mr *MockDatastoreMockRecorder) PutHeader(arg0, arg1, arg2, arg3 interface{
 }
 
 // PutPayload mocks base method.
-func (m *MockDatastore) PutPayload(arg0 context.Context, arg1 types.Hash, arg2 *relay.BlockBidAndTrace, arg3 time.Duration) error {
+func (m *MockDatastore) PutPayload(arg0 context.Context, arg1 relay.PayloadKey, arg2 *relay.BlockBidAndTrace, arg3 time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutPayload", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/pkg/datastore_test.go
+++ b/pkg/datastore_test.go
@@ -238,11 +238,16 @@ func TestPutGetPayload(t *testing.T) {
 	payload := randomBlockBidAndTrace()
 
 	// put
-	err := ds.PutPayload(ctx, payload.Payload.Data.BlockHash, payload, time.Minute)
+	key := relay.PayloadKey{
+		BlockHash: payload.Trace.Message.BlockHash,
+		Proposer:  payload.Trace.Message.ProposerPubkey,
+		Slot:      relay.Slot(payload.Trace.Message.Slot),
+	}
+	err := ds.PutPayload(ctx, key, payload, time.Minute)
 	require.NoError(t, err)
 
 	// get
-	gotPayload, err := ds.GetPayload(ctx, payload.Payload.Data.BlockHash)
+	gotPayload, err := ds.GetPayload(ctx, key)
 	require.NoError(t, err)
 	require.EqualValues(t, *payload, *gotPayload)
 }

--- a/pkg/relay_test.go
+++ b/pkg/relay_test.go
@@ -99,7 +99,8 @@ func TestGetHeader(t *testing.T) {
 	payload := relay.SubmitBlockRequestToBlockBidAndTrace(signedBuilderBid, submitRequest)
 
 	// fill the datastore
-	err = ds.PutPayload(ctx, submitRequest.Message.BlockHash, &payload, time.Minute)
+	key := relay.SubmissionToKey(submitRequest)
+	err = ds.PutPayload(ctx, key, &payload, time.Minute)
 	require.NoError(t, err)
 	header, err := types.PayloadToPayloadHeader(submitRequest.ExecutionPayload)
 	require.NoError(t, err)
@@ -188,7 +189,12 @@ func TestGetPayload(t *testing.T) {
 	payload := relay.SubmitBlockRequestToBlockBidAndTrace(signedBuilderBid, submitRequest)
 
 	// fill the datastore
-	err = ds.PutPayload(ctx, submitRequest.Message.BlockHash, &payload, time.Minute)
+	key := relay.PayloadKey{
+		BlockHash: request.Message.Body.ExecutionPayloadHeader.BlockHash,
+		Proposer:  registration.Message.Pubkey,
+		Slot:      relay.Slot(request.Message.Slot),
+	}
+	err = ds.PutPayload(ctx, key, &payload, time.Minute)
 	require.NoError(t, err)
 	err = ds.PutHeader(ctx, relay.Slot(submitRequest.Message.Slot),
 		relay.HeaderAndTrace{
@@ -260,7 +266,8 @@ func TestSubmitBlock(t *testing.T) {
 	require.NoError(t, err)
 	payload := relay.SubmitBlockRequestToBlockBidAndTrace(signedBuilderBid, submitRequest)
 
-	gotPayload, err := ds.GetPayload(ctx, submitRequest.Message.BlockHash)
+	key := relay.SubmissionToKey(submitRequest)
+	gotPayload, err := ds.GetPayload(ctx, key)
 	require.NoError(t, err)
 	require.EqualValues(t, payload, *gotPayload)
 
@@ -395,7 +402,8 @@ func BenchmarkGetHeader(b *testing.B) {
 	payload := relay.SubmitBlockRequestToBlockBidAndTrace(signedBuilderBid, submitRequest)
 
 	// fill the datastore
-	_ = ds.PutPayload(ctx, submitRequest.Message.BlockHash, &payload, time.Minute)
+	key := relay.SubmissionToKey(submitRequest)
+	_ = ds.PutPayload(ctx, key, &payload, time.Minute)
 	header, _ := types.PayloadToPayloadHeader(submitRequest.ExecutionPayload)
 	_ = ds.PutHeader(ctx, relay.Slot(submitRequest.Message.Slot),
 		relay.HeaderAndTrace{
@@ -455,7 +463,8 @@ func BenchmarkGetHeaderParallel(b *testing.B) {
 	payload := relay.SubmitBlockRequestToBlockBidAndTrace(signedBuilderBid, submitRequest)
 
 	// fill the datastore
-	_ = ds.PutPayload(ctx, submitRequest.Message.BlockHash, &payload, time.Minute)
+	key := relay.SubmissionToKey(submitRequest)
+	_ = ds.PutPayload(ctx, key, &payload, time.Minute)
 	header, _ := types.PayloadToPayloadHeader(submitRequest.ExecutionPayload)
 	_ = ds.PutHeader(ctx, relay.Slot(submitRequest.Message.Slot),
 		relay.HeaderAndTrace{
@@ -545,7 +554,12 @@ func BenchmarkGetPayload(b *testing.B) {
 	payload := relay.SubmitBlockRequestToBlockBidAndTrace(signedBuilderBid, submitRequest)
 
 	// fill the datastore
-	_ = ds.PutPayload(ctx, submitRequest.Message.BlockHash, &payload, time.Minute)
+	key := relay.PayloadKey{
+		BlockHash: request.Message.Body.ExecutionPayloadHeader.BlockHash,
+		Proposer:  registration.Message.Pubkey,
+		Slot:      relay.Slot(request.Message.Slot),
+	}
+	_ = ds.PutPayload(ctx, key, &payload, time.Minute)
 	_ = ds.PutHeader(ctx, relay.Slot(submitRequest.Message.Slot),
 		relay.HeaderAndTrace{
 			Header: header,
@@ -628,7 +642,12 @@ func BenchmarkGetPayloadParallel(b *testing.B) {
 	payload := relay.SubmitBlockRequestToBlockBidAndTrace(signedBuilderBid, submitRequest)
 
 	// fill the datastore
-	_ = ds.PutPayload(ctx, submitRequest.Message.BlockHash, &payload, time.Minute)
+	key := relay.PayloadKey{
+		BlockHash: request.Message.Body.ExecutionPayloadHeader.BlockHash,
+		Proposer:  registration.Message.Pubkey,
+		Slot:      relay.Slot(request.Message.Slot),
+	}
+	_ = ds.PutPayload(ctx, key, &payload, time.Minute)
 	_ = ds.PutHeader(ctx, relay.Slot(submitRequest.Message.Slot),
 		relay.HeaderAndTrace{
 			Header: header,


### PR DESCRIPTION
# What 🕵️‍♀️
This PR improves getPayload security based on the issue #6 

# Why 🔑
In order to avoid a validator to steal the payload without risk of slashing

# How ⚙️
Checking the slot and proposer pubkey, apart from the BlockHash when retriving the payload from the datastore

# Testing 🧪
All the tests have been updated based on this new security improvement