### PR TITLE
Fix/get delivered payload

### DIFF
--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -428,7 +428,15 @@ func (rs *DefaultRelay) SubmitBlock(ctx context.Context, submitBlockRequest *typ
 	h := HeaderAndTrace{
 		Header: header,
 		Trace: &BidTraceWithTimestamp{
-			BidTrace:  *submitBlockRequest.Message,
+			BidTrace: types.BidTrace{
+				Slot:                 submitBlockRequest.Message.Slot,
+				ParentHash:           payload.Payload.Data.ParentHash,
+				BlockHash:            payload.Payload.Data.BlockHash,
+				BuilderPubkey:        payload.Trace.Message.BuilderPubkey,
+				ProposerPubkey:       payload.Trace.Message.ProposerPubkey,
+				ProposerFeeRecipient: payload.Payload.Data.FeeRecipient,
+				Value:                payload.Trace.Message.Value,
+			},
 			Timestamp: uint64(time.Now().UnixMicro()),
 		},
 	}

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -485,7 +485,7 @@ func simulateBlock() bool {
 
 func SubmissionToKey(submission *types.BuilderSubmitBlockRequest) PayloadKey {
 	return PayloadKey{
-		BlockHash: submission.Message.BlockHash,
+		BlockHash: submission.ExecutionPayload.BlockHash,
 		Proposer:  submission.Message.ProposerPubkey,
 		Slot:      Slot(submission.Message.Slot),
 	}


### PR DESCRIPTION
# What 🕵️‍♀️
This PR fixes the Data API by using the correct block hash. Currently we are using the Blockhash from BidTrace of the block submission, but this is not correct. We should be using the ExecutionPayload Blockhash 

