### PR TITLE
fix registration logic

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -36,7 +36,7 @@ type PubKey struct{ types.PublicKey }
 
 func (pk PubKey) Loggable() map[string]any {
 	return map[string]any{
-		"pub_key": pk,
+		"pubkey": pk,
 	}
 }
 
@@ -124,8 +124,8 @@ type builder struct {
 
 func (b builder) Loggable() map[string]any {
 	return map[string]any{
-		"pub_key": b.PubKey,
-		"url":     b.URL,
+		"pubkey": b.PubKey,
+		"url":    b.URL,
 	}
 }
 

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -109,18 +109,18 @@ func (rs *DefaultRelay) RegisterValidator(ctx context.Context, payload []types.S
 		}
 		g.Go(func() error {
 			registered := rs.processValidator(ctx, payload[start:end], state)
-			atomic.AddInt64(&totalRegistered, int64(registered))
+			atomic.AddInt64(&totalRegistered, registered)
 			return nil
 		})
 	}
 
 	if err := g.Wait(); err != nil {
-		logger.WithError(err).WithField("requests", len(payload)).WithField("registered", totalRegistered).Debug("validator registration failed")
+		logger.WithError(err).WithField("numberValidators", len(payload)).WithField("registered", totalRegistered).Debug("validator registration failed")
 		return err
 	}
 
 	if totalRegistered != int64(len(payload)) {
-		logger.WithField("requests", len(payload)).WithField("registered", totalRegistered).Debug("validators registration failed")
+		logger.WithField("numberValidators", len(payload)).WithField("registered", totalRegistered).Debug("validators registration failed")
 		return ErrPartialregistration
 	}
 

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -209,9 +209,9 @@ func (rs *DefaultRelay) processValidator(ctx context.Context, payload []types.Si
 	}
 
 	logger.With(log.F{
-		"processingTimeMs":          time.Since(timeStart).Milliseconds(),
-		"partitionNumberValidators": len(payload),
-		"registered":                registered,
+		"processingTimeMs": time.Since(timeStart).Milliseconds(),
+		"numberValidators": len(payload),
+		"registered":       registered,
 	}).Trace("validator batch registered")
 
 	return registered

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -134,7 +134,7 @@ func (rs *DefaultRelay) RegisterValidator(ctx context.Context, payload []types.S
 }
 
 func (rs *DefaultRelay) processValidator(ctx context.Context, payload []types.SignedValidatorRegistration, state State) int64 {
-	logger := rs.Log().WithField("method", "RegisterValidator")
+	logger := rs.Log().WithField("method", "ProcessValidator")
 	timeStart := time.Now()
 	registered := int64(0)
 

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -209,9 +209,9 @@ func (rs *DefaultRelay) processValidator(ctx context.Context, payload []types.Si
 	}
 
 	logger.With(log.F{
-		"processingTimeMs": time.Since(timeStart).Milliseconds(),
-		"numberValidators": len(payload),
-		"registered":       registered,
+		"processingTimeMs":          time.Since(timeStart).Milliseconds(),
+		"partitionNumberValidators": len(payload),
+		"registered":                registered,
 	}).Trace("validator batch registered")
 
 	return registered

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -165,7 +165,7 @@ func (rs *DefaultRelay) processValidator(ctx context.Context, payload []types.Si
 		} else if !ok {
 			logger.WithField("pubkey", pk.PublicKey).Debug("is not a known validator")
 			if rs.config.CheckKnownValidator {
-				logger.WithField("pubkey", registerRequest.Message.Pubkey).Error("is not a known validator")
+				logger.WithField("pubkey", registerRequest.Message.Pubkey).Debug("is not a known validator")
 				continue
 			} else {
 


### PR DESCRIPTION
# What 🕵️‍♀️
This PR improves validator registration logic. Currently, as soon as registration fails, the remaining validators are not registered. However, with this PR even if a single registration fails, then the rest of validators are registered.
