### PR TITLE
Fix/improve Data API builder_blocks_received

### DIFF
--- a/pkg/api.go
+++ b/pkg/api.go
@@ -41,7 +41,7 @@ const (
 )
 
 const (
-	dataLimit = 200
+	DataLimit = 200
 )
 
 var (
@@ -261,7 +261,7 @@ func (a *API) proposerPayloadsDelivered(w http.ResponseWriter, r *http.Request) 
 	if isInvalidParameter(err) {
 		return http.StatusBadRequest, err
 	} else if errors.Is(err, ErrParamNotFound) {
-		limit = dataLimit
+		limit = DataLimit
 	}
 
 	cursor, err := cursor(r)
@@ -302,7 +302,7 @@ func (a *API) builderBlocksReceived(w http.ResponseWriter, r *http.Request) (int
 	if isInvalidParameter(err) {
 		return http.StatusBadRequest, err
 	} else if errors.Is(err, ErrParamNotFound) {
-		limit = dataLimit
+		limit = DataLimit
 	}
 
 	query := TraceQuery{
@@ -375,8 +375,8 @@ func limit(r *http.Request) (uint64, error) {
 		limit, err := strconv.ParseUint(limitStr, 10, 64)
 		if err != nil{
 			return 0, err
-		} else if dataLimit<limit{
-			return 0, fmt.Errorf("limit is higher than %d", dataLimit)
+		} else if DataLimit<limit{
+			return 0, fmt.Errorf("limit is higher than %d", DataLimit)
 		}
 		return limit, err
 	}

--- a/pkg/api_test.go
+++ b/pkg/api_test.go
@@ -156,7 +156,7 @@ func TestServerRouting(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		service.EXPECT().
-			GetBlockReceived(gomock.Any(), relay.TraceQuery{Limit: 100, Slot: 100}).
+			GetBlockReceived(gomock.Any(), relay.TraceQuery{Limit: relay.DataLimit, Slot: 100}).
 			Times(1)
 
 		server.ServeHTTP(w, req)
@@ -180,7 +180,7 @@ func TestServerRouting(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		service.EXPECT().
-			GetBlockReceived(gomock.Any(), relay.TraceQuery{Limit: 100, BlockHash: blockHash}).
+			GetBlockReceived(gomock.Any(), relay.TraceQuery{Limit: relay.DataLimit, BlockHash: blockHash}).
 			Times(1)
 
 		server.ServeHTTP(w, req)
@@ -203,7 +203,7 @@ func TestServerRouting(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		service.EXPECT().
-			GetBlockReceived(gomock.Any(), relay.TraceQuery{Limit: 100, BlockNum: 100}).
+			GetBlockReceived(gomock.Any(), relay.TraceQuery{Limit: relay.DataLimit, BlockNum: 100}).
 			Times(1)
 
 		server.ServeHTTP(w, req)
@@ -248,7 +248,7 @@ func TestServerRouting(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		service.EXPECT().
-			GetBlockReceived(gomock.Any(), relay.TraceQuery{Limit: 100}).
+			GetBlockReceived(gomock.Any(), relay.TraceQuery{Limit: relay.DataLimit}).
 			Times(1)
 
 		server.ServeHTTP(w, req)
@@ -271,7 +271,7 @@ func TestServerRouting(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		service.EXPECT().
-			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: 100, Slot: 100}).
+			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: relay.DataLimit, Slot: 100}).
 			Times(1)
 
 		server.ServeHTTP(w, req)
@@ -295,7 +295,7 @@ func TestServerRouting(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		service.EXPECT().
-			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: 100, BlockHash: blockHash}).
+			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: relay.DataLimit, BlockHash: blockHash}).
 			Times(1)
 
 		server.ServeHTTP(w, req)
@@ -319,7 +319,7 @@ func TestServerRouting(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		service.EXPECT().
-			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: 100, BlockNum: 100}).
+			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: relay.DataLimit, BlockNum: 100}).
 			Times(1)
 
 		server.ServeHTTP(w, req)
@@ -342,7 +342,7 @@ func TestServerRouting(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		service.EXPECT().
-			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: 100, Cursor: 50}).
+			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: relay.DataLimit, Cursor: 50}).
 			Times(1)
 
 		server.ServeHTTP(w, req)
@@ -387,7 +387,7 @@ func TestServerRouting(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		service.EXPECT().
-			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: 100}).
+			GetPayloadDelivered(gomock.Any(), relay.TraceQuery{Limit: relay.DataLimit}).
 			Times(1)
 
 		server.ServeHTTP(w, req)

--- a/pkg/datastore.go
+++ b/pkg/datastore.go
@@ -127,7 +127,7 @@ func (s *DefaultDatastore) getHeaders(ctx context.Context, key ds.Key) ([]Header
 }
 
 func (s *DefaultDatastore) filterHeaders(headers []HeaderAndTrace, query Query) []HeaderAndTrace {
-	var filtered []HeaderAndTrace
+	filtered := headers[:0]
 	for _, header := range headers {
 		if (query.BlockHash != types.Hash{}) && (query.BlockHash != header.Header.BlockHash) {
 			continue

--- a/pkg/datastore.go
+++ b/pkg/datastore.go
@@ -83,6 +83,10 @@ func (s *DefaultDatastore) PutHeader(ctx context.Context, slot Slot, header Head
 		return err
 	}
 
+	if 0 < len(headers) && headers[len(headers)-1].Header.BlockHash == header.Header.BlockHash {
+		return nil // deduplicate
+	}
+
 	headers = append(headers, header)
 
 	if err := s.TTLStorage.PutWithTTL(ctx, HeaderHashKey(header.Header.BlockHash), HeaderKey(slot).Bytes(), ttl); err != nil {

--- a/pkg/datastore.go
+++ b/pkg/datastore.go
@@ -114,7 +114,7 @@ func (s *DefaultDatastore) GetHeaders(ctx context.Context, query Query) ([]Heade
 		return nil, err
 	}
 
-	return s.filterHeaders(headers, query), nil
+	return s.deduplicateHeaders(headers, query), nil
 }
 
 func (s *DefaultDatastore) getHeaders(ctx context.Context, key ds.Key) ([]HeaderAndTrace, error) {
@@ -126,7 +126,7 @@ func (s *DefaultDatastore) getHeaders(ctx context.Context, key ds.Key) ([]Header
 	return s.unsmarshalHeaders(data)
 }
 
-func (s *DefaultDatastore) filterHeaders(headers []HeaderAndTrace, query Query) []HeaderAndTrace {
+func (s *DefaultDatastore) deduplicateHeaders(headers []HeaderAndTrace, query Query) []HeaderAndTrace {
 	filtered := headers[:0]
 	for _, header := range headers {
 		if (query.BlockHash != types.Hash{}) && (query.BlockHash != header.Header.BlockHash) {

--- a/pkg/datastore.go
+++ b/pkg/datastore.go
@@ -109,7 +109,12 @@ func (s *DefaultDatastore) GetHeaders(ctx context.Context, query Query) ([]Heade
 	if err != nil {
 		return nil, err
 	}
-	return s.getHeaders(ctx, key)
+	headers, err := s.getHeaders(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.filterHeaders(headers, query), nil
 }
 
 func (s *DefaultDatastore) getHeaders(ctx context.Context, key ds.Key) ([]HeaderAndTrace, error) {
@@ -119,6 +124,27 @@ func (s *DefaultDatastore) getHeaders(ctx context.Context, key ds.Key) ([]Header
 	}
 
 	return s.unsmarshalHeaders(data)
+}
+
+func (s *DefaultDatastore) filterHeaders(headers []HeaderAndTrace, query Query) []HeaderAndTrace {
+	var filtered []HeaderAndTrace
+	for _, header := range headers {
+		if (query.BlockHash != types.Hash{}) && (query.BlockHash != header.Header.BlockHash) {
+			continue
+		}
+		if (query.BlockNum != 0) && (query.BlockNum != header.Header.BlockNumber) {
+			continue
+		}
+		if (query.Slot != 0) && (uint64(query.Slot) != header.Trace.Slot) {
+			continue
+		}
+		if (query.PubKey != types.PublicKey{}) && (query.PubKey != header.Trace.ProposerPubkey) {
+			continue
+		}
+		filtered = append(filtered, header)
+	}
+
+	return filtered
 }
 
 func (s *DefaultDatastore) PutDelivered(ctx context.Context, slot Slot, trace DeliveredTrace, ttl time.Duration) error {
@@ -189,30 +215,25 @@ func (s *DefaultDatastore) GetDeliveredBatch(ctx context.Context, queries []Quer
 }
 
 func (s *DefaultDatastore) GetHeaderBatch(ctx context.Context, queries []Query) ([]HeaderAndTrace, error) {
-	keys := make([]ds.Key, 0, len(queries))
+	var batch []HeaderAndTrace
+
 	for _, query := range queries {
 		key, err := s.queryToHeaderKey(ctx, query)
 		if err != nil {
 			return nil, err
 		}
-		keys = append(keys, key)
-	}
 
-	batch, err := s.TTLStorage.GetBatch(ctx, keys)
-	if err != nil {
-		return nil, err
-	}
-
-	headerBatch := make([]HeaderAndTrace, 0, len(batch))
-	for _, data := range batch {
-		headers, err := s.unsmarshalHeaders(data)
-		if err != nil {
+		headers, err := s.getHeaders(ctx, key)
+		if errors.Is(err, ds.ErrNotFound) {
+			continue
+		} else if err != nil {
 			return nil, err
 		}
-		headerBatch = append(headerBatch, headers...)
+
+		batch = append(batch, headers...)
 	}
 
-	return headerBatch, err
+	return batch, nil
 }
 
 func (s *DefaultDatastore) unsmarshalHeaders(data []byte) ([]HeaderAndTrace, error) {

--- a/pkg/datastore_test.go
+++ b/pkg/datastore_test.go
@@ -54,6 +54,33 @@ func TestPutGetHeader(t *testing.T) {
 	require.EqualValues(t, *header.Header, *gotHeader[0].Header)
 }
 
+func TestPutGetHeaderDuplicate(t *testing.T) {
+	t.Parallel()
+
+	const N = 10
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ds := relay.DefaultDatastore{TTLStorage: newMockDatastore()}
+
+	header := randomHeaderAndTrace()
+	slot := relay.Slot(rand.Int())
+
+	for i := 0; i < N; i++ {
+		// put
+		err := ds.PutHeader(ctx, slot, header, time.Minute)
+		require.NoError(t, err)
+	}
+
+	// get
+	gotHeaders, err := ds.GetHeaders(ctx, relay.Query{Slot: slot})
+	require.NoError(t, err)
+	require.Len(t, gotHeaders, 1)
+	require.EqualValues(t, header.Trace.Value, gotHeaders[0].Trace.Value)
+	require.EqualValues(t, *header.Header, *gotHeaders[0].Header)
+}
+
 func TestPutGetHeaders(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# What 🕵️‍♀️
This PR 
(1) deduplicates Headers. Currently, headers are stored as an array, and when we add a new one we simply append to the list. However, this may lead to having hundreds of duplicate headers, which obscures the Data API. So, in this PR we add the logic for deduplicating the headers.

(2) Fixes the data API. Currently we are not correctly serving the indexed queries. We return more than what user asks for.

# How ⚙️
Before appending a new header we check if the tail of the headers is the same as the one currently being stored. For checking equality only the `BlockHash` is used.

# Testing 🧪
I added a regression test for checking deduplication works as expected
