### PR TITLE
Feature/multi builder support

### DIFF
--- a/cmd/dreamboat/main.go
+++ b/cmd/dreamboat/main.go
@@ -59,15 +59,15 @@ var flags = []cli.Flag{
 		Usage:   "`url` for beacon endpoint",
 		EnvVars: []string{"RELAY_BEACON"},
 	},
-	&cli.BoolFlag{
-		Name:    "check-builders",
-		Usage:   "check builder blocks",
-		EnvVars: []string{"RELAY_CHECK_BUILDERS"},
+	&cli.StringSliceFlag{
+		Name:    "simulation",
+		Usage:   "`url` for simulation cluster endpoint",
+		EnvVars: []string{"RELAY_SIMULATION"},
 	},
 	&cli.StringSliceFlag{
 		Name:    "builder",
 		Usage:   "`url` formatted as schema://pubkey@host",
-		EnvVars: []string{"BN_RELAY_BUILDER_URLS"},
+		EnvVars: []string{"RELAY_BUILDER_URLS"},
 	},
 	&cli.StringFlag{
 		Name:    "network",
@@ -91,7 +91,7 @@ var flags = []cli.Flag{
 		Name:    "ttl",
 		Usage:   "ttl of the data",
 		Value:   24 * time.Hour,
-		EnvVars: []string{"BN_RELAY_TTL"},
+		EnvVars: []string{"RELAY_TTL"},
 	},
 	&cli.BoolFlag{
 		Name:  "checkKnownValidator",
@@ -132,9 +132,9 @@ func setup() cli.BeforeFunc {
 			Log:                 logger(c),
 			RelayRequestTimeout: c.Duration("timeout"),
 			Network:             c.String("network"),
-			BuilderCheck:        c.Bool("check-builder"),
 			BuilderURLs:         c.StringSlice("builder"),
 			BeaconEndpoints:     c.StringSlice("beacon"),
+			SimulationEndpoint:  c.String("simulation"),
 			PubKey:              pk,
 			SecretKey:           sk,
 			Datadir:             c.String("datadir"),

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	RelayRequestTimeout time.Duration
 	BuilderCheck        bool
 	BeaconEndpoints     []string
+	SimulationEndpoint  string
 	PubKey              types.PublicKey
 	SecretKey           *bls.SecretKey
 	Datadir             string

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -73,6 +73,10 @@ func (c *Config) validate() error {
 		return err
 	}
 
+	if err := c.validateSimulationEndpoint(); err != nil {
+		return err
+	}
+
 	return c.validateBuilders()
 }
 
@@ -102,6 +106,14 @@ func (c *Config) validateNetwork() error {
 		return errors.New("unknown network")
 	}
 	return nil
+}
+
+func (c *Config) validateSimulationEndpoint() error {
+	u, err := url.Parse(c.SimulationEndpoint)
+	if err == nil && u.Scheme != "" && u.Host != "" {
+		return nil
+	}
+	return errors.New("invalid simulation endpoint")
 }
 
 func (c *Config) validateBuilders() (err error) {

--- a/pkg/datastore_test.go
+++ b/pkg/datastore_test.go
@@ -585,35 +585,6 @@ func validSubmitBlockRequest(t require.TestingT, domain types.Domain) *types.Bui
 	}
 }
 
-func validSignedBlindedBeaconBlock(t require.TestingT, domain types.Domain) *types.BuilderSubmitBlockRequest {
-	sk, pk, err := bls.GenerateNewKeypair()
-	require.NoError(t, err)
-
-	var pubKey types.PublicKey
-	pubKey.FromSlice(pk.Compress())
-
-	payload := randomPayload()
-
-	msg := &types.BidTrace{
-		Slot:                 rand.Uint64(),
-		ParentHash:           types.Hash(random32Bytes()),
-		BlockHash:            types.Hash(random32Bytes()),
-		BuilderPubkey:        types.PublicKey(random48Bytes()),
-		ProposerPubkey:       types.PublicKey(random48Bytes()),
-		ProposerFeeRecipient: types.Address(random20Bytes()),
-		Value:                types.IntToU256(rand.Uint64()),
-	}
-
-	signature, err := types.SignMessage(msg, domain, sk)
-	require.NoError(t, err)
-
-	return &types.BuilderSubmitBlockRequest{
-		Signature:        signature,
-		Message:          msg,
-		ExecutionPayload: payload,
-	}
-}
-
 func random32Bytes() (b [32]byte) {
 	rand.Read(b[:])
 	return b

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -485,7 +485,7 @@ func (rs *DefaultRelay) SubmitBlock(ctx context.Context, submitBlockRequest *typ
 				ParentHash:           payload.Payload.Data.ParentHash,
 				BlockHash:            payload.Payload.Data.BlockHash,
 				BuilderPubkey:        payload.Trace.Message.BuilderPubkey,
-				ProposerPubkey:       payload.Trace.Message.ProposerPubkey,git
+				ProposerPubkey:       payload.Trace.Message.ProposerPubkey,
 				ProposerFeeRecipient: payload.Payload.Data.FeeRecipient,
 				Value:                submitBlockRequest.Message.Value,
 			},

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -485,13 +485,17 @@ func (rs *DefaultRelay) SubmitBlock(ctx context.Context, submitBlockRequest *typ
 				ParentHash:           payload.Payload.Data.ParentHash,
 				BlockHash:            payload.Payload.Data.BlockHash,
 				BuilderPubkey:        payload.Trace.Message.BuilderPubkey,
-				ProposerPubkey:       payload.Trace.Message.ProposerPubkey,
+				ProposerPubkey:       payload.Trace.Message.ProposerPubkey,git
 				ProposerFeeRecipient: payload.Payload.Data.FeeRecipient,
 				Value:                submitBlockRequest.Message.Value,
 			},
 			Timestamp: payload.Payload.Data.Timestamp,
 		},
 	}
+
+	// TODO : store an array of headers, one per new builder
+	// This opens a DDOS vector of sending the same block from many different pubkeys
+	// first pass solution :we should limit to 1.5 x current number of builders.
 
 	err = state.Datastore().PutHeader(ctx, slot, h, rs.config.TTL)
 

--- a/pkg/relay_test.go
+++ b/pkg/relay_test.go
@@ -2,6 +2,7 @@ package relay_test
 
 import (
 	"context"
+	"math/rand"
 	"strconv"
 	"sync"
 	"testing"
@@ -16,6 +17,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func setTestUpRelay() (*relay.DefaultRelay, error) {
+	config := relay.Config{Log: log.New(), Network: "ropsten", TTL: time.Minute}
+	r, err := relay.NewRelay(config)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+
+}
+
 func TestRegisterValidator(t *testing.T) {
 	t.Parallel()
 
@@ -26,8 +37,7 @@ func TestRegisterValidator(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 
-	config := relay.Config{Log: log.New(), Network: "ropsten", TTL: time.Minute}
-	r, _ := relay.NewRelay(config)
+	r, _ := setTestUpRelay()
 	ds := &relay.DefaultDatastore{TTLStorage: newMockDatastore()}
 	bc := mock_relay.NewMockBeaconState(ctrl)
 
@@ -70,7 +80,7 @@ func TestGetHeader(t *testing.T) {
 	sk, _, _ := bls.GenerateNewKeypair()
 	config := relay.Config{Log: log.New(),
 		Network:   "ropsten",
-		SecretKey: sk,  // pragma: allowlist secret
+		SecretKey: sk, // pragma: allowlist secret
 		PubKey:    types.PublicKey(random48Bytes())}
 	r, _ := relay.NewRelay(config)
 	ds := &relay.DefaultDatastore{TTLStorage: newMockDatastore()}
@@ -136,7 +146,7 @@ func TestGetPayload(t *testing.T) {
 	pk, _, _ := bls.GenerateNewKeypair()
 	config := relay.Config{Log: log.New(),
 		Network:   "ropsten",
-		SecretKey: pk,  //pragma: allowlist secret
+		SecretKey: pk, //pragma: allowlist secret
 		PubKey:    types.PublicKey(random48Bytes()),
 		TTL:       time.Minute}
 	r, _ := relay.NewRelay(config)
@@ -279,6 +289,111 @@ func TestSubmitBlock(t *testing.T) {
 	require.EqualValues(t, header, gotHeaders[0].Header)
 }
 
+func TestSubmitBlocksTwoBuilders(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctrl := gomock.NewController(t)
+
+	sk, _, _ := bls.GenerateNewKeypair()
+	config := relay.Config{Log: log.New(), Network: "ropsten", SecretKey: sk, TTL: time.Minute}
+	r, _ := relay.NewRelay(config)
+	ds := &relay.DefaultDatastore{TTLStorage: newMockDatastore()}
+	bc := mock_relay.NewMockBeaconState(ctrl)
+
+	relaySigningDomain, err := relay.ComputeDomain(
+		types.DomainTypeAppBuilder,
+		relay.GenesisForkVersionRopsten,
+		types.Root{}.String())
+	require.NoError(t, err)
+
+	// generate and send 1st block
+	skB1, pkB1, err := bls.GenerateNewKeypair()
+	require.NoError(t, err)
+
+	var pubKeyB1 types.PublicKey
+	pubKeyB1.FromSlice(pkB1.Compress())
+
+	payloadB1 := randomPayload()
+
+	msgB1 := &types.BidTrace{
+		Slot:                 rand.Uint64(),
+		ParentHash:           payloadB1.ParentHash,
+		BlockHash:            payloadB1.BlockHash,
+		BuilderPubkey:        pubKeyB1,
+		ProposerPubkey:       types.PublicKey(random48Bytes()),
+		ProposerFeeRecipient: types.Address(random20Bytes()),
+		Value:                types.IntToU256(10),
+	}
+
+	signatureB1, err := types.SignMessage(msgB1, relaySigningDomain, skB1)
+	require.NoError(t, err)
+
+	submitRequestOne := &types.BuilderSubmitBlockRequest{
+		Signature:        signatureB1,
+		Message:          msgB1,
+		ExecutionPayload: payloadB1,
+	}
+
+	err = r.SubmitBlock(ctx, submitRequestOne, state{ds: ds, bc: bc})
+	require.NoError(t, err)
+
+	// generate and send 2nd block
+	skB2, pkB2, err := bls.GenerateNewKeypair()
+	require.NoError(t, err)
+
+	var pubKeyB2 types.PublicKey
+	pubKeyB1.FromSlice(pkB2.Compress())
+
+	payloadB2 := randomPayload()
+
+	msgB2 := &types.BidTrace{
+		Slot:                 rand.Uint64(),
+		ParentHash:           payloadB2.ParentHash,
+		BlockHash:            payloadB2.BlockHash,
+		BuilderPubkey:        pubKeyB2,
+		ProposerPubkey:       types.PublicKey(random48Bytes()),
+		ProposerFeeRecipient: types.Address(random20Bytes()),
+		Value:                types.IntToU256(1000),
+	}
+
+	signatureB2, err := types.SignMessage(msgB2, relaySigningDomain, skB2)
+	require.NoError(t, err)
+
+	submitRequestTwo := &types.BuilderSubmitBlockRequest{
+		Signature:        signatureB2,
+		Message:          msgB2,
+		ExecutionPayload: payloadB2,
+	}
+
+	err = r.SubmitBlock(ctx, submitRequestTwo, state{ds: ds, bc: bc})
+	require.NoError(t, err)
+
+	// check that payload served from relay is 2nd builders
+	signedBuilderBid, err := relay.SubmitBlockRequestToSignedBuilderBid(
+		submitRequestOne,
+		config.SecretKey,
+		&config.PubKey,
+		relaySigningDomain)
+	require.NoError(t, err)
+	payload := relay.SubmitBlockRequestToBlockBidAndTrace(signedBuilderBid, submitRequestOne)
+
+	key := relay.SubmissionToKey(submitRequestOne)
+	gotPayload, err := ds.GetPayload(ctx, key)
+	require.NoError(t, err)
+	require.EqualValues(t, payload, *gotPayload)
+
+	header, err := types.PayloadToPayloadHeader(submitRequestOne.ExecutionPayload)
+	require.NoError(t, err)
+	gotHeaders, err := ds.GetHeaders(ctx, relay.Query{Slot: relay.Slot(submitRequestOne.Message.Slot)})
+
+	require.NoError(t, err)
+	require.Len(t, gotHeaders, 1)
+	require.EqualValues(t, header, gotHeaders[0].Header)
+}
+
 func BenchmarkRegisterValidator(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -376,7 +491,7 @@ func BenchmarkGetHeader(b *testing.B) {
 	pk, _, _ := bls.GenerateNewKeypair()
 	config := relay.Config{Log: log.New(),
 		Network:   "ropsten",
-		SecretKey: pk,  // pragma: allowlist secret
+		SecretKey: pk, // pragma: allowlist secret
 		PubKey:    types.PublicKey(random48Bytes())}
 	r, _ := relay.NewRelay(config)
 	ds := &relay.DefaultDatastore{TTLStorage: newMockDatastore()}
@@ -437,7 +552,7 @@ func BenchmarkGetHeaderParallel(b *testing.B) {
 	pk, _, _ := bls.GenerateNewKeypair()
 	config := relay.Config{Log: log.New(),
 		Network:   "ropsten",
-		SecretKey: pk,  // pragma: allowlist secret
+		SecretKey: pk, // pragma: allowlist secret
 		PubKey:    types.PublicKey(random48Bytes())}
 	r, _ := relay.NewRelay(config)
 	ds := &relay.DefaultDatastore{TTLStorage: newMockDatastore()}
@@ -506,7 +621,7 @@ func BenchmarkGetPayload(b *testing.B) {
 	pk, _, _ := bls.GenerateNewKeypair()
 	config := relay.Config{Log: log.New(),
 		Network:   "ropsten",
-		SecretKey: pk,  // pragma: allowlist secret
+		SecretKey: pk, // pragma: allowlist secret
 		PubKey:    types.PublicKey(random48Bytes())}
 	r, _ := relay.NewRelay(config)
 	ds := &relay.DefaultDatastore{TTLStorage: newMockDatastore()}
@@ -594,7 +709,7 @@ func BenchmarkGetPayloadParallel(b *testing.B) {
 	pk, _, _ := bls.GenerateNewKeypair()
 	config := relay.Config{Log: log.New(),
 		Network:   "ropsten",
-		SecretKey: pk,  // pragma: allowlist secret
+		SecretKey: pk, // pragma: allowlist secret
 		PubKey:    types.PublicKey(random48Bytes())}
 	r, _ := relay.NewRelay(config)
 	ds := &relay.DefaultDatastore{TTLStorage: newMockDatastore()}
@@ -688,7 +803,7 @@ func BenchmarkSubmitBlock(b *testing.B) {
 	ctrl := gomock.NewController(b)
 
 	pk, _, _ := bls.GenerateNewKeypair()
-	config := relay.Config{Log: log.New(), Network: "ropsten", SecretKey: pk}  // pragma: allowlist secret
+	config := relay.Config{Log: log.New(), Network: "ropsten", SecretKey: pk} // pragma: allowlist secret
 	r, _ := relay.NewRelay(config)
 	ds := &relay.DefaultDatastore{TTLStorage: newMockDatastore()}
 	bc := mock_relay.NewMockBeaconState(ctrl)
@@ -717,7 +832,7 @@ func BenchmarkSubmitBlockParallel(b *testing.B) {
 	ctrl := gomock.NewController(b)
 
 	pk, _, _ := bls.GenerateNewKeypair()
-	config := relay.Config{Log: log.New(), Network: "ropsten", SecretKey: pk}  // pragma: allowlist secret
+	config := relay.Config{Log: log.New(), Network: "ropsten", SecretKey: pk} // pragma: allowlist secret
 	r, _ := relay.NewRelay(config)
 	ds := &relay.DefaultDatastore{TTLStorage: newMockDatastore()}
 	bc := mock_relay.NewMockBeaconState(ctrl)


### PR DESCRIPTION
# What 🕵️‍♀️
Explain what this PR accomplishes

- Changes the `check-builder` flag to `simulation` and adds validation. This is in preparation for adding support for _external_ builders, the rest of this PR simply focuses on _multiple builder support_.

Support for multiple builders:
- The main consideration in this implementation is preserving the ability for builders to cancel blocks, this is inline with comments brought up in mev-boost and also with [issue #202](https://github.com/flashbots/mev-boost-relay/issues/202
) in the flashbots relay 
- this implementation stores every builders last valid submission and updates the best payload stored in the relay upon receiving a valid payload.

# Why 🔑
Explain the need or decisions which make this change necessary




# How ⚙️
Briefly explain what components you modified or added, and how, to give context to your reviewers

# Testing 🧪
- [ ] `go test ./...` from root
