### PR TITLE
Multiple builder submissions

### DIFF
--- a/pkg/datastore.go
+++ b/pkg/datastore.go
@@ -172,6 +172,7 @@ func (s *DefaultDatastore) putMaxProfitHeader(ctx context.Context, slot Slot, he
 	for ; i < len(headers); i++ {
 		if headers[i].Trace.BuilderPubkey == header.Trace.BuilderPubkey {
 			headers[i] = header
+			break
 		}
 	}
 	if i == len(headers) {

--- a/pkg/datastore.go
+++ b/pkg/datastore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -56,6 +57,7 @@ type DeliveredTrace struct {
 type Datastore interface {
 	PutHeader(context.Context, Slot, HeaderAndTrace, time.Duration) error
 	GetHeaders(context.Context, Query) ([]HeaderAndTrace, error)
+	GetMaxProfitHeadersDesc(context.Context, Slot) ([]HeaderAndTrace, error)
 	GetHeaderBatch(context.Context, []Query) ([]HeaderAndTrace, error)
 	PutDelivered(context.Context, Slot, DeliveredTrace, time.Duration) error
 	GetDelivered(context.Context, Query) (BidTraceWithTimestamp, error)
@@ -101,6 +103,10 @@ func (s *DefaultDatastore) PutHeader(ctx context.Context, slot Slot, header Head
 
 	if err := s.TTLStorage.PutWithTTL(ctx, HeaderNumKey(header.Header.BlockNumber), HeaderKey(slot).Bytes(), ttl); err != nil {
 		return err
+	}
+
+	if err := s.putMaxProfitHeader(ctx, slot, header, ttl); err != nil {
+		return fmt.Errorf("fail to set header in max profit list: %w", err)
 	}
 
 	data, err := json.Marshal(headers)
@@ -151,6 +157,41 @@ func (s *DefaultDatastore) deduplicateHeaders(headers []HeaderAndTrace, query Qu
 	}
 
 	return filtered
+}
+
+func (s *DefaultDatastore) putMaxProfitHeader(ctx context.Context, slot Slot, header HeaderAndTrace, ttl time.Duration) error {
+	headers, err := s.getHeaders(ctx, HeaderMaxProfitKey(slot))
+	if errors.Is(err, ds.ErrNotFound) {
+		headers = make([]HeaderAndTrace, 0, 1)
+	} else if err != nil && !errors.Is(err, ds.ErrNotFound) {
+		return err
+	}
+
+	// remove submission from same builder
+	i := 0
+	for ; i < len(headers); i++ {
+		if headers[i].Trace.BuilderPubkey == header.Trace.BuilderPubkey {
+			headers[i] = header
+		}
+	}
+	if i == len(headers) {
+		headers = append(headers, header)
+	}
+
+	// sort by bid value DESC
+	sort.Slice(headers, func(i, j int) bool {
+		return headers[i].Trace.Value.Cmp(&headers[j].Trace.Value) > 0
+	})
+
+	data, err := json.Marshal(headers)
+	if err != nil {
+		return err
+	}
+	return s.TTLStorage.PutWithTTL(ctx, HeaderMaxProfitKey(slot), data, ttl)
+}
+
+func (s *DefaultDatastore) GetMaxProfitHeadersDesc(ctx context.Context, slot Slot) ([]HeaderAndTrace, error) {
+	return s.getHeaders(ctx, HeaderMaxProfitKey(slot))
 }
 
 func (s *DefaultDatastore) PutDelivered(ctx context.Context, slot Slot, trace DeliveredTrace, ttl time.Duration) error {
@@ -334,6 +375,10 @@ func (s *DefaultDatastore) queryToDeliveredKey(ctx context.Context, query Query)
 
 func HeaderKey(slot Slot) ds.Key {
 	return ds.NewKey(fmt.Sprintf("header-%d", slot))
+}
+
+func HeaderMaxProfitKey(slot Slot) ds.Key {
+	return ds.NewKey(fmt.Sprintf("header/max-profit/%d", slot))
 }
 
 func HeaderHashKey(bh types.Hash) ds.Key {

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -242,13 +242,13 @@ func (rs *DefaultRelay) GetHeader(ctx context.Context, request HeaderRequest, st
 		return nil, fmt.Errorf("unknown validator")
 	}
 
-	headers, err := state.Datastore().GetHeaders(ctx, Query{Slot: slot})
+	headers, err := state.Datastore().GetMaxProfitHeadersDesc(ctx, slot)
 	if err != nil || len(headers) < 1 {
 		logger.Warn(noBuilderBidMsg)
 		return nil, fmt.Errorf(noBuilderBidMsg)
 	}
 
-	header := headers[len(headers)-1] // choose the received last header
+	header := headers[0] // choose the highest bid, which is index 0
 
 	if header.Header == nil || (header.Header.ParentHash != parentHash) {
 		log.Debug(badHeaderMsg)


### PR DESCRIPTION
# What 🕵️‍♀️
This PR makes Dreamboat to be multi-builder, so that multiple builders can submit blocks. The relay chooses the highest bid among different builders. The intuition of the implementation is that a separate list of max profit bids is stored. In this list we keep the latest submission of every builder. So when a validator queries for a header, we get the max profit headers list, we sort them by bid (descending), and we select the highest bid.


# Testing 🧪
 We still need to write tests @dmarzzz 
