### PR TITLE
propFeeRecipient from bidTrace not exec payload

### DIFF
--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -492,7 +492,7 @@ func (rs *DefaultRelay) SubmitBlock(ctx context.Context, submitBlockRequest *typ
 					BlockHash:            payload.Payload.Data.BlockHash,
 					BuilderPubkey:        payload.Trace.Message.BuilderPubkey,
 					ProposerPubkey:       payload.Trace.Message.ProposerPubkey,
-					ProposerFeeRecipient: payload.Payload.Data.FeeRecipient,
+					ProposerFeeRecipient: payload.Trace.Message.ProposerFeeRecipient,
 					Value:                submitBlockRequest.Message.Value,
 					GasLimit:             payload.Trace.Message.GasLimit,
 					GasUsed:              payload.Trace.Message.GasUsed,


### PR DESCRIPTION
# What 🕵️‍♀️
Explain what this PR accomplishes

- changes the source of the proposer_fee_recipient field to bidTrace as opposed to the eth execution payload feeRecipient value.

# Why 🔑
Explain the need or decisions which make this change necessary

- Currently when a builder with proposer payments sends blocks to our relay, it will now show the validators preferred fee recipient, but instead the fee recipient in the execution payload. This issue did not make itself known because the main builder being used with dreamboat in prod did not support proposer payments.

# How ⚙️
Briefly explain what components you modified or added, and how, to give context to your reviewers
 - simple change of field source

# Testing 🧪
- [x] `go test -race ./...` from root
