### PR TITLE
Fix data api underflow on low slots

### DIFF
--- a/pkg/service.go
+++ b/pkg/service.go
@@ -322,12 +322,12 @@ func (s *Service) getTailDelivered(ctx context.Context, limit, cursor uint64) ([
 		start = min(headSlot, structs.Slot(cursor))
 	}
 
-	stop := start - structs.Slot(s.Config.TTL/DurationPerSlot)
+	stop := start - min(structs.Slot(s.Config.TTL/DurationPerSlot), start)
 
 	batch := make([]structs.BidTraceWithTimestamp, 0, limit)
 	queries := make([]structs.PayloadQuery, 0, limit)
 
-	for highSlot := start; len(batch) < int(limit) && stop <= highSlot; highSlot -= structs.Slot(limit) {
+	for highSlot := start; len(batch) < int(limit) && stop <= highSlot; highSlot -= min(structs.Slot(limit), highSlot) {
 		queries = queries[:0]
 		for s := highSlot; highSlot-structs.Slot(limit) < s && stop <= s; s-- {
 			queries = append(queries, structs.PayloadQuery{Slot: s})


### PR DESCRIPTION
# What 🕵️‍♀️
This PR fixes `uint64` overflows on low slot numbers, when querying data api tail values. Currently, if the `headslot` is lower than `TTL/DurationPerSlot`, it overflows when retrieving tails of delivered payloads and submitted blocks.

# How ⚙️
I added checks in the stop values as well as the steps of the iteration over the slots when querying the tail.
