### PR TITLE
Add timestamp validation on block submission

### DIFF
--- a/internal/mock/pkg/beacon.go
+++ b/internal/mock/pkg/beacon.go
@@ -50,10 +50,10 @@ func (mr *MockBeaconClientMockRecorder) Endpoint() *gomock.Call {
 }
 
 // Genesis mocks base method.
-func (m *MockBeaconClient) Genesis() (*relay.GenesisInfo, error) {
+func (m *MockBeaconClient) Genesis() (relay.GenesisInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Genesis")
-	ret0, _ := ret[0].(*relay.GenesisInfo)
+	ret0, _ := ret[0].(relay.GenesisInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/mock/pkg/beacon.go
+++ b/internal/mock/pkg/beacon.go
@@ -50,10 +50,10 @@ func (mr *MockBeaconClientMockRecorder) Endpoint() *gomock.Call {
 }
 
 // Genesis mocks base method.
-func (m *MockBeaconClient) Genesis() (*relay.GenesisResponse, error) {
+func (m *MockBeaconClient) Genesis() (*relay.GenesisInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Genesis")
-	ret0, _ := ret[0].(*relay.GenesisResponse)
+	ret0, _ := ret[0].(*relay.GenesisInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/mock/pkg/beacon.go
+++ b/internal/mock/pkg/beacon.go
@@ -6,47 +6,65 @@ package mock_relay
 
 import (
 	context "context"
+	reflect "reflect"
+
 	relay "github.com/blocknative/dreamboat/pkg"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockBeaconClient is a mock of BeaconClient interface
+// MockBeaconClient is a mock of BeaconClient interface.
 type MockBeaconClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockBeaconClientMockRecorder
 }
 
-// MockBeaconClientMockRecorder is the mock recorder for MockBeaconClient
+// MockBeaconClientMockRecorder is the mock recorder for MockBeaconClient.
 type MockBeaconClientMockRecorder struct {
 	mock *MockBeaconClient
 }
 
-// NewMockBeaconClient creates a new mock instance
+// NewMockBeaconClient creates a new mock instance.
 func NewMockBeaconClient(ctrl *gomock.Controller) *MockBeaconClient {
 	mock := &MockBeaconClient{ctrl: ctrl}
 	mock.recorder = &MockBeaconClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBeaconClient) EXPECT() *MockBeaconClientMockRecorder {
 	return m.recorder
 }
 
-// SubscribeToHeadEvents mocks base method
-func (m *MockBeaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan relay.HeadEvent) {
+// Endpoint mocks base method.
+func (m *MockBeaconClient) Endpoint() string {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SubscribeToHeadEvents", ctx, slotC)
+	ret := m.ctrl.Call(m, "Endpoint")
+	ret0, _ := ret[0].(string)
+	return ret0
 }
 
-// SubscribeToHeadEvents indicates an expected call of SubscribeToHeadEvents
-func (mr *MockBeaconClientMockRecorder) SubscribeToHeadEvents(ctx, slotC interface{}) *gomock.Call {
+// Endpoint indicates an expected call of Endpoint.
+func (mr *MockBeaconClientMockRecorder) Endpoint() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeToHeadEvents", reflect.TypeOf((*MockBeaconClient)(nil).SubscribeToHeadEvents), ctx, slotC)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Endpoint", reflect.TypeOf((*MockBeaconClient)(nil).Endpoint))
 }
 
-// GetProposerDuties mocks base method
+// GetGenesis mocks base method.
+func (m *MockBeaconClient) GetGenesis() (*relay.GenesisResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGenesis")
+	ret0, _ := ret[0].(*relay.GenesisResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGenesis indicates an expected call of GetGenesis.
+func (mr *MockBeaconClientMockRecorder) GetGenesis() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenesis", reflect.TypeOf((*MockBeaconClient)(nil).GetGenesis))
+}
+
+// GetProposerDuties mocks base method.
 func (m *MockBeaconClient) GetProposerDuties(arg0 relay.Epoch) (*relay.RegisteredProposersResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProposerDuties", arg0)
@@ -55,28 +73,13 @@ func (m *MockBeaconClient) GetProposerDuties(arg0 relay.Epoch) (*relay.Registere
 	return ret0, ret1
 }
 
-// GetProposerDuties indicates an expected call of GetProposerDuties
+// GetProposerDuties indicates an expected call of GetProposerDuties.
 func (mr *MockBeaconClientMockRecorder) GetProposerDuties(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposerDuties", reflect.TypeOf((*MockBeaconClient)(nil).GetProposerDuties), arg0)
 }
 
-// SyncStatus mocks base method
-func (m *MockBeaconClient) SyncStatus() (*relay.SyncStatusPayloadData, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncStatus")
-	ret0, _ := ret[0].(*relay.SyncStatusPayloadData)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SyncStatus indicates an expected call of SyncStatus
-func (mr *MockBeaconClientMockRecorder) SyncStatus() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MockBeaconClient)(nil).SyncStatus))
-}
-
-// KnownValidators mocks base method
+// KnownValidators mocks base method.
 func (m *MockBeaconClient) KnownValidators(arg0 relay.Slot) (relay.AllValidatorsResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KnownValidators", arg0)
@@ -85,22 +88,35 @@ func (m *MockBeaconClient) KnownValidators(arg0 relay.Slot) (relay.AllValidators
 	return ret0, ret1
 }
 
-// KnownValidators indicates an expected call of KnownValidators
+// KnownValidators indicates an expected call of KnownValidators.
 func (mr *MockBeaconClientMockRecorder) KnownValidators(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownValidators", reflect.TypeOf((*MockBeaconClient)(nil).KnownValidators), arg0)
 }
 
-// Endpoint mocks base method
-func (m *MockBeaconClient) Endpoint() string {
+// SubscribeToHeadEvents mocks base method.
+func (m *MockBeaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan relay.HeadEvent) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Endpoint")
-	ret0, _ := ret[0].(string)
-	return ret0
+	m.ctrl.Call(m, "SubscribeToHeadEvents", ctx, slotC)
 }
 
-// Endpoint indicates an expected call of Endpoint
-func (mr *MockBeaconClientMockRecorder) Endpoint() *gomock.Call {
+// SubscribeToHeadEvents indicates an expected call of SubscribeToHeadEvents.
+func (mr *MockBeaconClientMockRecorder) SubscribeToHeadEvents(ctx, slotC interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Endpoint", reflect.TypeOf((*MockBeaconClient)(nil).Endpoint))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeToHeadEvents", reflect.TypeOf((*MockBeaconClient)(nil).SubscribeToHeadEvents), ctx, slotC)
+}
+
+// SyncStatus mocks base method.
+func (m *MockBeaconClient) SyncStatus() (*relay.SyncStatusPayloadData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncStatus")
+	ret0, _ := ret[0].(*relay.SyncStatusPayloadData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SyncStatus indicates an expected call of SyncStatus.
+func (mr *MockBeaconClientMockRecorder) SyncStatus() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MockBeaconClient)(nil).SyncStatus))
 }

--- a/internal/mock/pkg/beacon.go
+++ b/internal/mock/pkg/beacon.go
@@ -49,19 +49,19 @@ func (mr *MockBeaconClientMockRecorder) Endpoint() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Endpoint", reflect.TypeOf((*MockBeaconClient)(nil).Endpoint))
 }
 
-// GetGenesis mocks base method.
-func (m *MockBeaconClient) GetGenesis() (*relay.GenesisResponse, error) {
+// Genesis mocks base method.
+func (m *MockBeaconClient) Genesis() (*relay.GenesisResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGenesis")
+	ret := m.ctrl.Call(m, "Genesis")
 	ret0, _ := ret[0].(*relay.GenesisResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetGenesis indicates an expected call of GetGenesis.
-func (mr *MockBeaconClientMockRecorder) GetGenesis() *gomock.Call {
+// Genesis indicates an expected call of Genesis.
+func (mr *MockBeaconClientMockRecorder) Genesis() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenesis", reflect.TypeOf((*MockBeaconClient)(nil).GetGenesis))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Genesis", reflect.TypeOf((*MockBeaconClient)(nil).Genesis))
 }
 
 // GetProposerDuties mocks base method.

--- a/internal/mock/pkg/datastore.go
+++ b/internal/mock/pkg/datastore.go
@@ -6,96 +6,39 @@ package mock_relay
 
 import (
 	context "context"
+	reflect "reflect"
+	time "time"
+
 	relay "github.com/blocknative/dreamboat/pkg"
 	types "github.com/flashbots/go-boost-utils/types"
 	gomock "github.com/golang/mock/gomock"
 	datastore "github.com/ipfs/go-datastore"
-	reflect "reflect"
-	time "time"
 )
 
-// MockDatastore is a mock of Datastore interface
+// MockDatastore is a mock of Datastore interface.
 type MockDatastore struct {
 	ctrl     *gomock.Controller
 	recorder *MockDatastoreMockRecorder
 }
 
-// MockDatastoreMockRecorder is the mock recorder for MockDatastore
+// MockDatastoreMockRecorder is the mock recorder for MockDatastore.
 type MockDatastoreMockRecorder struct {
 	mock *MockDatastore
 }
 
-// NewMockDatastore creates a new mock instance
+// NewMockDatastore creates a new mock instance.
 func NewMockDatastore(ctrl *gomock.Controller) *MockDatastore {
 	mock := &MockDatastore{ctrl: ctrl}
 	mock.recorder = &MockDatastoreMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDatastore) EXPECT() *MockDatastoreMockRecorder {
 	return m.recorder
 }
 
-// PutHeader mocks base method
-func (m *MockDatastore) PutHeader(arg0 context.Context, arg1 relay.Slot, arg2 relay.HeaderAndTrace, arg3 time.Duration) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutHeader", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PutHeader indicates an expected call of PutHeader
-func (mr *MockDatastoreMockRecorder) PutHeader(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutHeader", reflect.TypeOf((*MockDatastore)(nil).PutHeader), arg0, arg1, arg2, arg3)
-}
-
-// GetHeaders mocks base method
-func (m *MockDatastore) GetHeaders(arg0 context.Context, arg1 relay.Query) ([]relay.HeaderAndTrace, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHeaders", arg0, arg1)
-	ret0, _ := ret[0].([]relay.HeaderAndTrace)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHeaders indicates an expected call of GetHeaders
-func (mr *MockDatastoreMockRecorder) GetHeaders(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaders", reflect.TypeOf((*MockDatastore)(nil).GetHeaders), arg0, arg1)
-}
-
-// GetHeaderBatch mocks base method
-func (m *MockDatastore) GetHeaderBatch(arg0 context.Context, arg1 []relay.Query) ([]relay.HeaderAndTrace, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHeaderBatch", arg0, arg1)
-	ret0, _ := ret[0].([]relay.HeaderAndTrace)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHeaderBatch indicates an expected call of GetHeaderBatch
-func (mr *MockDatastoreMockRecorder) GetHeaderBatch(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderBatch", reflect.TypeOf((*MockDatastore)(nil).GetHeaderBatch), arg0, arg1)
-}
-
-// PutDelivered mocks base method
-func (m *MockDatastore) PutDelivered(arg0 context.Context, arg1 relay.Slot, arg2 relay.DeliveredTrace, arg3 time.Duration) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutDelivered", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PutDelivered indicates an expected call of PutDelivered
-func (mr *MockDatastoreMockRecorder) PutDelivered(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDelivered", reflect.TypeOf((*MockDatastore)(nil).PutDelivered), arg0, arg1, arg2, arg3)
-}
-
-// GetDelivered mocks base method
+// GetDelivered mocks base method.
 func (m *MockDatastore) GetDelivered(arg0 context.Context, arg1 relay.Query) (relay.BidTraceWithTimestamp, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDelivered", arg0, arg1)
@@ -104,13 +47,13 @@ func (m *MockDatastore) GetDelivered(arg0 context.Context, arg1 relay.Query) (re
 	return ret0, ret1
 }
 
-// GetDelivered indicates an expected call of GetDelivered
+// GetDelivered indicates an expected call of GetDelivered.
 func (mr *MockDatastoreMockRecorder) GetDelivered(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDelivered", reflect.TypeOf((*MockDatastore)(nil).GetDelivered), arg0, arg1)
 }
 
-// GetDeliveredBatch mocks base method
+// GetDeliveredBatch mocks base method.
 func (m *MockDatastore) GetDeliveredBatch(arg0 context.Context, arg1 []relay.Query) ([]relay.BidTraceWithTimestamp, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeliveredBatch", arg0, arg1)
@@ -119,27 +62,58 @@ func (m *MockDatastore) GetDeliveredBatch(arg0 context.Context, arg1 []relay.Que
 	return ret0, ret1
 }
 
-// GetDeliveredBatch indicates an expected call of GetDeliveredBatch
+// GetDeliveredBatch indicates an expected call of GetDeliveredBatch.
 func (mr *MockDatastoreMockRecorder) GetDeliveredBatch(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeliveredBatch", reflect.TypeOf((*MockDatastore)(nil).GetDeliveredBatch), arg0, arg1)
 }
 
-// PutPayload mocks base method
-func (m *MockDatastore) PutPayload(arg0 context.Context, arg1 relay.PayloadKey, arg2 *relay.BlockBidAndTrace, arg3 time.Duration) error {
+// GetHeaderBatch mocks base method.
+func (m *MockDatastore) GetHeaderBatch(arg0 context.Context, arg1 []relay.Query) ([]relay.HeaderAndTrace, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutPayload", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetHeaderBatch", arg0, arg1)
+	ret0, _ := ret[0].([]relay.HeaderAndTrace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// PutPayload indicates an expected call of PutPayload
-func (mr *MockDatastoreMockRecorder) PutPayload(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// GetHeaderBatch indicates an expected call of GetHeaderBatch.
+func (mr *MockDatastoreMockRecorder) GetHeaderBatch(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutPayload", reflect.TypeOf((*MockDatastore)(nil).PutPayload), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderBatch", reflect.TypeOf((*MockDatastore)(nil).GetHeaderBatch), arg0, arg1)
 }
 
-// GetPayload mocks base method
+// GetHeaders mocks base method.
+func (m *MockDatastore) GetHeaders(arg0 context.Context, arg1 relay.Query) ([]relay.HeaderAndTrace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHeaders", arg0, arg1)
+	ret0, _ := ret[0].([]relay.HeaderAndTrace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHeaders indicates an expected call of GetHeaders.
+func (mr *MockDatastoreMockRecorder) GetHeaders(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaders", reflect.TypeOf((*MockDatastore)(nil).GetHeaders), arg0, arg1)
+}
+
+// GetMaxProfitHeadersDesc mocks base method.
+func (m *MockDatastore) GetMaxProfitHeadersDesc(arg0 context.Context, arg1 relay.Slot) ([]relay.HeaderAndTrace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxProfitHeadersDesc", arg0, arg1)
+	ret0, _ := ret[0].([]relay.HeaderAndTrace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMaxProfitHeadersDesc indicates an expected call of GetMaxProfitHeadersDesc.
+func (mr *MockDatastoreMockRecorder) GetMaxProfitHeadersDesc(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxProfitHeadersDesc", reflect.TypeOf((*MockDatastore)(nil).GetMaxProfitHeadersDesc), arg0, arg1)
+}
+
+// GetPayload mocks base method.
 func (m *MockDatastore) GetPayload(arg0 context.Context, arg1 relay.PayloadKey) (*relay.BlockBidAndTrace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPayload", arg0, arg1)
@@ -148,27 +122,13 @@ func (m *MockDatastore) GetPayload(arg0 context.Context, arg1 relay.PayloadKey) 
 	return ret0, ret1
 }
 
-// GetPayload indicates an expected call of GetPayload
+// GetPayload indicates an expected call of GetPayload.
 func (mr *MockDatastoreMockRecorder) GetPayload(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPayload", reflect.TypeOf((*MockDatastore)(nil).GetPayload), arg0, arg1)
 }
 
-// PutRegistration mocks base method
-func (m *MockDatastore) PutRegistration(arg0 context.Context, arg1 relay.PubKey, arg2 types.SignedValidatorRegistration, arg3 time.Duration) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutRegistration", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PutRegistration indicates an expected call of PutRegistration
-func (mr *MockDatastoreMockRecorder) PutRegistration(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRegistration", reflect.TypeOf((*MockDatastore)(nil).PutRegistration), arg0, arg1, arg2, arg3)
-}
-
-// GetRegistration mocks base method
+// GetRegistration mocks base method.
 func (m *MockDatastore) GetRegistration(arg0 context.Context, arg1 relay.PubKey) (types.SignedValidatorRegistration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegistration", arg0, arg1)
@@ -177,50 +137,106 @@ func (m *MockDatastore) GetRegistration(arg0 context.Context, arg1 relay.PubKey)
 	return ret0, ret1
 }
 
-// GetRegistration indicates an expected call of GetRegistration
+// GetRegistration indicates an expected call of GetRegistration.
 func (mr *MockDatastoreMockRecorder) GetRegistration(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistration", reflect.TypeOf((*MockDatastore)(nil).GetRegistration), arg0, arg1)
 }
 
-// MockTTLStorage is a mock of TTLStorage interface
+// PutDelivered mocks base method.
+func (m *MockDatastore) PutDelivered(arg0 context.Context, arg1 relay.Slot, arg2 relay.DeliveredTrace, arg3 time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutDelivered", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutDelivered indicates an expected call of PutDelivered.
+func (mr *MockDatastoreMockRecorder) PutDelivered(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDelivered", reflect.TypeOf((*MockDatastore)(nil).PutDelivered), arg0, arg1, arg2, arg3)
+}
+
+// PutHeader mocks base method.
+func (m *MockDatastore) PutHeader(arg0 context.Context, arg1 relay.Slot, arg2 relay.HeaderAndTrace, arg3 time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutHeader", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutHeader indicates an expected call of PutHeader.
+func (mr *MockDatastoreMockRecorder) PutHeader(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutHeader", reflect.TypeOf((*MockDatastore)(nil).PutHeader), arg0, arg1, arg2, arg3)
+}
+
+// PutPayload mocks base method.
+func (m *MockDatastore) PutPayload(arg0 context.Context, arg1 relay.PayloadKey, arg2 *relay.BlockBidAndTrace, arg3 time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutPayload", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutPayload indicates an expected call of PutPayload.
+func (mr *MockDatastoreMockRecorder) PutPayload(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutPayload", reflect.TypeOf((*MockDatastore)(nil).PutPayload), arg0, arg1, arg2, arg3)
+}
+
+// PutRegistration mocks base method.
+func (m *MockDatastore) PutRegistration(arg0 context.Context, arg1 relay.PubKey, arg2 types.SignedValidatorRegistration, arg3 time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutRegistration", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutRegistration indicates an expected call of PutRegistration.
+func (mr *MockDatastoreMockRecorder) PutRegistration(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRegistration", reflect.TypeOf((*MockDatastore)(nil).PutRegistration), arg0, arg1, arg2, arg3)
+}
+
+// MockTTLStorage is a mock of TTLStorage interface.
 type MockTTLStorage struct {
 	ctrl     *gomock.Controller
 	recorder *MockTTLStorageMockRecorder
 }
 
-// MockTTLStorageMockRecorder is the mock recorder for MockTTLStorage
+// MockTTLStorageMockRecorder is the mock recorder for MockTTLStorage.
 type MockTTLStorageMockRecorder struct {
 	mock *MockTTLStorage
 }
 
-// NewMockTTLStorage creates a new mock instance
+// NewMockTTLStorage creates a new mock instance.
 func NewMockTTLStorage(ctrl *gomock.Controller) *MockTTLStorage {
 	mock := &MockTTLStorage{ctrl: ctrl}
 	mock.recorder = &MockTTLStorageMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTTLStorage) EXPECT() *MockTTLStorageMockRecorder {
 	return m.recorder
 }
 
-// PutWithTTL mocks base method
-func (m *MockTTLStorage) PutWithTTL(arg0 context.Context, arg1 datastore.Key, arg2 []byte, arg3 time.Duration) error {
+// Close mocks base method.
+func (m *MockTTLStorage) Close() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutWithTTL", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Close")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// PutWithTTL indicates an expected call of PutWithTTL
-func (mr *MockTTLStorageMockRecorder) PutWithTTL(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// Close indicates an expected call of Close.
+func (mr *MockTTLStorageMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutWithTTL", reflect.TypeOf((*MockTTLStorage)(nil).PutWithTTL), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockTTLStorage)(nil).Close))
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockTTLStorage) Get(arg0 context.Context, arg1 datastore.Key) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
@@ -229,13 +245,13 @@ func (m *MockTTLStorage) Get(arg0 context.Context, arg1 datastore.Key) ([]byte, 
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockTTLStorageMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTTLStorage)(nil).Get), arg0, arg1)
 }
 
-// GetBatch mocks base method
+// GetBatch mocks base method.
 func (m *MockTTLStorage) GetBatch(ctx context.Context, keys []datastore.Key) ([][]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBatch", ctx, keys)
@@ -244,22 +260,22 @@ func (m *MockTTLStorage) GetBatch(ctx context.Context, keys []datastore.Key) ([]
 	return ret0, ret1
 }
 
-// GetBatch indicates an expected call of GetBatch
+// GetBatch indicates an expected call of GetBatch.
 func (mr *MockTTLStorageMockRecorder) GetBatch(ctx, keys interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBatch", reflect.TypeOf((*MockTTLStorage)(nil).GetBatch), ctx, keys)
 }
 
-// Close mocks base method
-func (m *MockTTLStorage) Close() error {
+// PutWithTTL mocks base method.
+func (m *MockTTLStorage) PutWithTTL(arg0 context.Context, arg1 datastore.Key, arg2 []byte, arg3 time.Duration) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
+	ret := m.ctrl.Call(m, "PutWithTTL", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Close indicates an expected call of Close
-func (mr *MockTTLStorageMockRecorder) Close() *gomock.Call {
+// PutWithTTL indicates an expected call of PutWithTTL.
+func (mr *MockTTLStorageMockRecorder) PutWithTTL(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockTTLStorage)(nil).Close))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutWithTTL", reflect.TypeOf((*MockTTLStorage)(nil).PutWithTTL), arg0, arg1, arg2, arg3)
 }

--- a/internal/mock/pkg/relay.go
+++ b/internal/mock/pkg/relay.go
@@ -6,50 +6,37 @@ package mock_relay
 
 import (
 	context "context"
+	reflect "reflect"
+
 	relay "github.com/blocknative/dreamboat/pkg"
 	types "github.com/flashbots/go-boost-utils/types"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockState is a mock of State interface
+// MockState is a mock of State interface.
 type MockState struct {
 	ctrl     *gomock.Controller
 	recorder *MockStateMockRecorder
 }
 
-// MockStateMockRecorder is the mock recorder for MockState
+// MockStateMockRecorder is the mock recorder for MockState.
 type MockStateMockRecorder struct {
 	mock *MockState
 }
 
-// NewMockState creates a new mock instance
+// NewMockState creates a new mock instance.
 func NewMockState(ctrl *gomock.Controller) *MockState {
 	mock := &MockState{ctrl: ctrl}
 	mock.recorder = &MockStateMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// Datastore mocks base method
-func (m *MockState) Datastore() relay.Datastore {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Datastore")
-	ret0, _ := ret[0].(relay.Datastore)
-	return ret0
-}
-
-// Datastore indicates an expected call of Datastore
-func (mr *MockStateMockRecorder) Datastore() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Datastore", reflect.TypeOf((*MockState)(nil).Datastore))
-}
-
-// Beacon mocks base method
+// Beacon mocks base method.
 func (m *MockState) Beacon() relay.BeaconState {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Beacon")
@@ -57,51 +44,78 @@ func (m *MockState) Beacon() relay.BeaconState {
 	return ret0
 }
 
-// Beacon indicates an expected call of Beacon
+// Beacon indicates an expected call of Beacon.
 func (mr *MockStateMockRecorder) Beacon() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Beacon", reflect.TypeOf((*MockState)(nil).Beacon))
 }
 
-// MockBeaconState is a mock of BeaconState interface
+// Datastore mocks base method.
+func (m *MockState) Datastore() relay.Datastore {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Datastore")
+	ret0, _ := ret[0].(relay.Datastore)
+	return ret0
+}
+
+// Datastore indicates an expected call of Datastore.
+func (mr *MockStateMockRecorder) Datastore() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Datastore", reflect.TypeOf((*MockState)(nil).Datastore))
+}
+
+// MockBeaconState is a mock of BeaconState interface.
 type MockBeaconState struct {
 	ctrl     *gomock.Controller
 	recorder *MockBeaconStateMockRecorder
 }
 
-// MockBeaconStateMockRecorder is the mock recorder for MockBeaconState
+// MockBeaconStateMockRecorder is the mock recorder for MockBeaconState.
 type MockBeaconStateMockRecorder struct {
 	mock *MockBeaconState
 }
 
-// NewMockBeaconState creates a new mock instance
+// NewMockBeaconState creates a new mock instance.
 func NewMockBeaconState(ctrl *gomock.Controller) *MockBeaconState {
 	mock := &MockBeaconState{ctrl: ctrl}
 	mock.recorder = &MockBeaconStateMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBeaconState) EXPECT() *MockBeaconStateMockRecorder {
 	return m.recorder
 }
 
-// KnownValidatorByIndex mocks base method
-func (m *MockBeaconState) KnownValidatorByIndex(arg0 uint64) (types.PubkeyHex, error) {
+// Genesis mocks base method.
+func (m *MockBeaconState) Genesis() relay.GenesisInfo {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KnownValidatorByIndex", arg0)
-	ret0, _ := ret[0].(types.PubkeyHex)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "Genesis")
+	ret0, _ := ret[0].(relay.GenesisInfo)
+	return ret0
 }
 
-// KnownValidatorByIndex indicates an expected call of KnownValidatorByIndex
-func (mr *MockBeaconStateMockRecorder) KnownValidatorByIndex(arg0 interface{}) *gomock.Call {
+// Genesis indicates an expected call of Genesis.
+func (mr *MockBeaconStateMockRecorder) Genesis() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownValidatorByIndex", reflect.TypeOf((*MockBeaconState)(nil).KnownValidatorByIndex), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Genesis", reflect.TypeOf((*MockBeaconState)(nil).Genesis))
 }
 
-// IsKnownValidator mocks base method
+// HeadSlot mocks base method.
+func (m *MockBeaconState) HeadSlot() relay.Slot {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HeadSlot")
+	ret0, _ := ret[0].(relay.Slot)
+	return ret0
+}
+
+// HeadSlot indicates an expected call of HeadSlot.
+func (mr *MockBeaconStateMockRecorder) HeadSlot() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadSlot", reflect.TypeOf((*MockBeaconState)(nil).HeadSlot))
+}
+
+// IsKnownValidator mocks base method.
 func (m *MockBeaconState) IsKnownValidator(arg0 types.PubkeyHex) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsKnownValidator", arg0)
@@ -110,27 +124,28 @@ func (m *MockBeaconState) IsKnownValidator(arg0 types.PubkeyHex) (bool, error) {
 	return ret0, ret1
 }
 
-// IsKnownValidator indicates an expected call of IsKnownValidator
+// IsKnownValidator indicates an expected call of IsKnownValidator.
 func (mr *MockBeaconStateMockRecorder) IsKnownValidator(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsKnownValidator", reflect.TypeOf((*MockBeaconState)(nil).IsKnownValidator), arg0)
 }
 
-// HeadSlot mocks base method
-func (m *MockBeaconState) HeadSlot() relay.Slot {
+// KnownValidatorByIndex mocks base method.
+func (m *MockBeaconState) KnownValidatorByIndex(arg0 uint64) (types.PubkeyHex, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HeadSlot")
-	ret0, _ := ret[0].(relay.Slot)
-	return ret0
+	ret := m.ctrl.Call(m, "KnownValidatorByIndex", arg0)
+	ret0, _ := ret[0].(types.PubkeyHex)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// HeadSlot indicates an expected call of HeadSlot
-func (mr *MockBeaconStateMockRecorder) HeadSlot() *gomock.Call {
+// KnownValidatorByIndex indicates an expected call of KnownValidatorByIndex.
+func (mr *MockBeaconStateMockRecorder) KnownValidatorByIndex(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadSlot", reflect.TypeOf((*MockBeaconState)(nil).HeadSlot))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnownValidatorByIndex", reflect.TypeOf((*MockBeaconState)(nil).KnownValidatorByIndex), arg0)
 }
 
-// ValidatorsMap mocks base method
+// ValidatorsMap mocks base method.
 func (m *MockBeaconState) ValidatorsMap() relay.BuilderGetValidatorsResponseEntrySlice {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidatorsMap")
@@ -138,50 +153,36 @@ func (m *MockBeaconState) ValidatorsMap() relay.BuilderGetValidatorsResponseEntr
 	return ret0
 }
 
-// ValidatorsMap indicates an expected call of ValidatorsMap
+// ValidatorsMap indicates an expected call of ValidatorsMap.
 func (mr *MockBeaconStateMockRecorder) ValidatorsMap() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorsMap", reflect.TypeOf((*MockBeaconState)(nil).ValidatorsMap))
 }
 
-// MockRelay is a mock of Relay interface
+// MockRelay is a mock of Relay interface.
 type MockRelay struct {
 	ctrl     *gomock.Controller
 	recorder *MockRelayMockRecorder
 }
 
-// MockRelayMockRecorder is the mock recorder for MockRelay
+// MockRelayMockRecorder is the mock recorder for MockRelay.
 type MockRelayMockRecorder struct {
 	mock *MockRelay
 }
 
-// NewMockRelay creates a new mock instance
+// NewMockRelay creates a new mock instance.
 func NewMockRelay(ctrl *gomock.Controller) *MockRelay {
 	mock := &MockRelay{ctrl: ctrl}
 	mock.recorder = &MockRelayMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRelay) EXPECT() *MockRelayMockRecorder {
 	return m.recorder
 }
 
-// RegisterValidator mocks base method
-func (m *MockRelay) RegisterValidator(arg0 context.Context, arg1 []types.SignedValidatorRegistration, arg2 relay.State) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterValidator", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RegisterValidator indicates an expected call of RegisterValidator
-func (mr *MockRelayMockRecorder) RegisterValidator(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterValidator", reflect.TypeOf((*MockRelay)(nil).RegisterValidator), arg0, arg1, arg2)
-}
-
-// GetHeader mocks base method
+// GetHeader mocks base method.
 func (m *MockRelay) GetHeader(arg0 context.Context, arg1 relay.HeaderRequest, arg2 relay.State) (*types.GetHeaderResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHeader", arg0, arg1, arg2)
@@ -190,13 +191,13 @@ func (m *MockRelay) GetHeader(arg0 context.Context, arg1 relay.HeaderRequest, ar
 	return ret0, ret1
 }
 
-// GetHeader indicates an expected call of GetHeader
+// GetHeader indicates an expected call of GetHeader.
 func (mr *MockRelayMockRecorder) GetHeader(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeader", reflect.TypeOf((*MockRelay)(nil).GetHeader), arg0, arg1, arg2)
 }
 
-// GetPayload mocks base method
+// GetPayload mocks base method.
 func (m *MockRelay) GetPayload(arg0 context.Context, arg1 *types.SignedBlindedBeaconBlock, arg2 relay.State) (*types.GetPayloadResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPayload", arg0, arg1, arg2)
@@ -205,27 +206,13 @@ func (m *MockRelay) GetPayload(arg0 context.Context, arg1 *types.SignedBlindedBe
 	return ret0, ret1
 }
 
-// GetPayload indicates an expected call of GetPayload
+// GetPayload indicates an expected call of GetPayload.
 func (mr *MockRelayMockRecorder) GetPayload(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPayload", reflect.TypeOf((*MockRelay)(nil).GetPayload), arg0, arg1, arg2)
 }
 
-// SubmitBlock mocks base method
-func (m *MockRelay) SubmitBlock(arg0 context.Context, arg1 *types.BuilderSubmitBlockRequest, arg2 relay.State) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitBlock", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SubmitBlock indicates an expected call of SubmitBlock
-func (mr *MockRelayMockRecorder) SubmitBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitBlock", reflect.TypeOf((*MockRelay)(nil).SubmitBlock), arg0, arg1, arg2)
-}
-
-// GetValidators mocks base method
+// GetValidators mocks base method.
 func (m *MockRelay) GetValidators(arg0 relay.State) relay.BuilderGetValidatorsResponseEntrySlice {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetValidators", arg0)
@@ -233,8 +220,36 @@ func (m *MockRelay) GetValidators(arg0 relay.State) relay.BuilderGetValidatorsRe
 	return ret0
 }
 
-// GetValidators indicates an expected call of GetValidators
+// GetValidators indicates an expected call of GetValidators.
 func (mr *MockRelayMockRecorder) GetValidators(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidators", reflect.TypeOf((*MockRelay)(nil).GetValidators), arg0)
+}
+
+// RegisterValidator mocks base method.
+func (m *MockRelay) RegisterValidator(arg0 context.Context, arg1 []types.SignedValidatorRegistration, arg2 relay.State) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterValidator", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegisterValidator indicates an expected call of RegisterValidator.
+func (mr *MockRelayMockRecorder) RegisterValidator(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterValidator", reflect.TypeOf((*MockRelay)(nil).RegisterValidator), arg0, arg1, arg2)
+}
+
+// SubmitBlock mocks base method.
+func (m *MockRelay) SubmitBlock(arg0 context.Context, arg1 *types.BuilderSubmitBlockRequest, arg2 relay.State) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubmitBlock", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SubmitBlock indicates an expected call of SubmitBlock.
+func (mr *MockRelayMockRecorder) SubmitBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitBlock", reflect.TypeOf((*MockRelay)(nil).SubmitBlock), arg0, arg1, arg2)
 }

--- a/internal/mock/pkg/service.go
+++ b/internal/mock/pkg/service.go
@@ -6,123 +6,37 @@ package mock_relay
 
 import (
 	context "context"
+	reflect "reflect"
+
 	relay "github.com/blocknative/dreamboat/pkg"
 	types "github.com/flashbots/go-boost-utils/types"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockRelayService is a mock of RelayService interface
+// MockRelayService is a mock of RelayService interface.
 type MockRelayService struct {
 	ctrl     *gomock.Controller
 	recorder *MockRelayServiceMockRecorder
 }
 
-// MockRelayServiceMockRecorder is the mock recorder for MockRelayService
+// MockRelayServiceMockRecorder is the mock recorder for MockRelayService.
 type MockRelayServiceMockRecorder struct {
 	mock *MockRelayService
 }
 
-// NewMockRelayService creates a new mock instance
+// NewMockRelayService creates a new mock instance.
 func NewMockRelayService(ctrl *gomock.Controller) *MockRelayService {
 	mock := &MockRelayService{ctrl: ctrl}
 	mock.recorder = &MockRelayServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRelayService) EXPECT() *MockRelayServiceMockRecorder {
 	return m.recorder
 }
 
-// RegisterValidator mocks base method
-func (m *MockRelayService) RegisterValidator(arg0 context.Context, arg1 []types.SignedValidatorRegistration) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterValidator", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RegisterValidator indicates an expected call of RegisterValidator
-func (mr *MockRelayServiceMockRecorder) RegisterValidator(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterValidator", reflect.TypeOf((*MockRelayService)(nil).RegisterValidator), arg0, arg1)
-}
-
-// GetHeader mocks base method
-func (m *MockRelayService) GetHeader(arg0 context.Context, arg1 relay.HeaderRequest) (*types.GetHeaderResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHeader", arg0, arg1)
-	ret0, _ := ret[0].(*types.GetHeaderResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHeader indicates an expected call of GetHeader
-func (mr *MockRelayServiceMockRecorder) GetHeader(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeader", reflect.TypeOf((*MockRelayService)(nil).GetHeader), arg0, arg1)
-}
-
-// GetPayload mocks base method
-func (m *MockRelayService) GetPayload(arg0 context.Context, arg1 *types.SignedBlindedBeaconBlock) (*types.GetPayloadResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPayload", arg0, arg1)
-	ret0, _ := ret[0].(*types.GetPayloadResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPayload indicates an expected call of GetPayload
-func (mr *MockRelayServiceMockRecorder) GetPayload(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPayload", reflect.TypeOf((*MockRelayService)(nil).GetPayload), arg0, arg1)
-}
-
-// SubmitBlock mocks base method
-func (m *MockRelayService) SubmitBlock(arg0 context.Context, arg1 *types.BuilderSubmitBlockRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitBlock", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SubmitBlock indicates an expected call of SubmitBlock
-func (mr *MockRelayServiceMockRecorder) SubmitBlock(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitBlock", reflect.TypeOf((*MockRelayService)(nil).SubmitBlock), arg0, arg1)
-}
-
-// GetValidators mocks base method
-func (m *MockRelayService) GetValidators() relay.BuilderGetValidatorsResponseEntrySlice {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetValidators")
-	ret0, _ := ret[0].(relay.BuilderGetValidatorsResponseEntrySlice)
-	return ret0
-}
-
-// GetValidators indicates an expected call of GetValidators
-func (mr *MockRelayServiceMockRecorder) GetValidators() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidators", reflect.TypeOf((*MockRelayService)(nil).GetValidators))
-}
-
-// GetPayloadDelivered mocks base method
-func (m *MockRelayService) GetPayloadDelivered(arg0 context.Context, arg1 relay.TraceQuery) ([]relay.BidTraceExtended, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPayloadDelivered", arg0, arg1)
-	ret0, _ := ret[0].([]relay.BidTraceExtended)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPayloadDelivered indicates an expected call of GetPayloadDelivered
-func (mr *MockRelayServiceMockRecorder) GetPayloadDelivered(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPayloadDelivered", reflect.TypeOf((*MockRelayService)(nil).GetPayloadDelivered), arg0, arg1)
-}
-
-// GetBlockReceived mocks base method
+// GetBlockReceived mocks base method.
 func (m *MockRelayService) GetBlockReceived(arg0 context.Context, arg1 relay.TraceQuery) ([]relay.BidTraceWithTimestamp, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockReceived", arg0, arg1)
@@ -131,13 +45,86 @@ func (m *MockRelayService) GetBlockReceived(arg0 context.Context, arg1 relay.Tra
 	return ret0, ret1
 }
 
-// GetBlockReceived indicates an expected call of GetBlockReceived
+// GetBlockReceived indicates an expected call of GetBlockReceived.
 func (mr *MockRelayServiceMockRecorder) GetBlockReceived(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockReceived", reflect.TypeOf((*MockRelayService)(nil).GetBlockReceived), arg0, arg1)
 }
 
-// Registration mocks base method
+// GetHeader mocks base method.
+func (m *MockRelayService) GetHeader(arg0 context.Context, arg1 relay.HeaderRequest) (*types.GetHeaderResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHeader", arg0, arg1)
+	ret0, _ := ret[0].(*types.GetHeaderResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHeader indicates an expected call of GetHeader.
+func (mr *MockRelayServiceMockRecorder) GetHeader(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeader", reflect.TypeOf((*MockRelayService)(nil).GetHeader), arg0, arg1)
+}
+
+// GetPayload mocks base method.
+func (m *MockRelayService) GetPayload(arg0 context.Context, arg1 *types.SignedBlindedBeaconBlock) (*types.GetPayloadResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPayload", arg0, arg1)
+	ret0, _ := ret[0].(*types.GetPayloadResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPayload indicates an expected call of GetPayload.
+func (mr *MockRelayServiceMockRecorder) GetPayload(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPayload", reflect.TypeOf((*MockRelayService)(nil).GetPayload), arg0, arg1)
+}
+
+// GetPayloadDelivered mocks base method.
+func (m *MockRelayService) GetPayloadDelivered(arg0 context.Context, arg1 relay.TraceQuery) ([]relay.BidTraceExtended, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPayloadDelivered", arg0, arg1)
+	ret0, _ := ret[0].([]relay.BidTraceExtended)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPayloadDelivered indicates an expected call of GetPayloadDelivered.
+func (mr *MockRelayServiceMockRecorder) GetPayloadDelivered(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPayloadDelivered", reflect.TypeOf((*MockRelayService)(nil).GetPayloadDelivered), arg0, arg1)
+}
+
+// GetValidators mocks base method.
+func (m *MockRelayService) GetValidators() relay.BuilderGetValidatorsResponseEntrySlice {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetValidators")
+	ret0, _ := ret[0].(relay.BuilderGetValidatorsResponseEntrySlice)
+	return ret0
+}
+
+// GetValidators indicates an expected call of GetValidators.
+func (mr *MockRelayServiceMockRecorder) GetValidators() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidators", reflect.TypeOf((*MockRelayService)(nil).GetValidators))
+}
+
+// RegisterValidator mocks base method.
+func (m *MockRelayService) RegisterValidator(arg0 context.Context, arg1 []types.SignedValidatorRegistration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterValidator", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegisterValidator indicates an expected call of RegisterValidator.
+func (mr *MockRelayServiceMockRecorder) RegisterValidator(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterValidator", reflect.TypeOf((*MockRelayService)(nil).RegisterValidator), arg0, arg1)
+}
+
+// Registration mocks base method.
 func (m *MockRelayService) Registration(arg0 context.Context, arg1 types.PublicKey) (types.SignedValidatorRegistration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Registration", arg0, arg1)
@@ -146,8 +133,22 @@ func (m *MockRelayService) Registration(arg0 context.Context, arg1 types.PublicK
 	return ret0, ret1
 }
 
-// Registration indicates an expected call of Registration
+// Registration indicates an expected call of Registration.
 func (mr *MockRelayServiceMockRecorder) Registration(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Registration", reflect.TypeOf((*MockRelayService)(nil).Registration), arg0, arg1)
+}
+
+// SubmitBlock mocks base method.
+func (m *MockRelayService) SubmitBlock(arg0 context.Context, arg1 *types.BuilderSubmitBlockRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubmitBlock", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SubmitBlock indicates an expected call of SubmitBlock.
+func (mr *MockRelayServiceMockRecorder) SubmitBlock(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitBlock", reflect.TypeOf((*MockRelayService)(nil).SubmitBlock), arg0, arg1)
 }

--- a/pkg/beacon.go
+++ b/pkg/beacon.go
@@ -31,7 +31,7 @@ type BeaconClient interface {
 	GetProposerDuties(Epoch) (*RegisteredProposersResponse, error)
 	SyncStatus() (*SyncStatusPayloadData, error)
 	KnownValidators(Slot) (AllValidatorsResponse, error)
-	Genesis() (*GenesisResponse, error)
+	Genesis() (*GenesisInfo, error)
 	Endpoint() string
 }
 
@@ -150,7 +150,7 @@ func (b *MultiBeaconClient) KnownValidators(headSlot Slot) (AllValidatorsRespons
 	return AllValidatorsResponse{}, ErrNodesUnavailable
 }
 
-func (b *MultiBeaconClient) Genesis() (genesisInfo *GenesisResponse, err error) {
+func (b *MultiBeaconClient) Genesis() (genesisInfo *GenesisInfo, err error) {
 	clients := b.clientsByLastResponse()
 	for _, client := range clients {
 		if genesisInfo, err = client.Genesis(); err != nil {
@@ -274,13 +274,13 @@ func (b *beaconClient) KnownValidators(headSlot Slot) (AllValidatorsResponse, er
 	return vd, err
 }
 
-func (b *beaconClient) Genesis() (*GenesisResponse, error) {
+func (b *beaconClient) Genesis() (*GenesisInfo, error) {
 	resp := new(GenesisResponse)
 	u := *b.beaconEndpoint
 	// https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/getSyncingStatus
 	u.Path = "/eth/v1/beacon/genesis"
 	err := b.queryBeacon(&u, "GET", &resp)
-	return resp, err
+	return &resp.Data, err
 }
 
 func (b *beaconClient) Endpoint() string {

--- a/pkg/beacon.go
+++ b/pkg/beacon.go
@@ -31,7 +31,7 @@ type BeaconClient interface {
 	GetProposerDuties(Epoch) (*RegisteredProposersResponse, error)
 	SyncStatus() (*SyncStatusPayloadData, error)
 	KnownValidators(Slot) (AllValidatorsResponse, error)
-	GetGenesis() (*GenesisResponse, error)
+	Genesis() (*GenesisResponse, error)
 	Endpoint() string
 }
 
@@ -150,10 +150,10 @@ func (b *MultiBeaconClient) KnownValidators(headSlot Slot) (AllValidatorsRespons
 	return AllValidatorsResponse{}, ErrNodesUnavailable
 }
 
-func (b *MultiBeaconClient) GetGenesis() (genesisInfo *GenesisResponse, err error) {
+func (b *MultiBeaconClient) Genesis() (genesisInfo *GenesisResponse, err error) {
 	clients := b.clientsByLastResponse()
 	for _, client := range clients {
-		if genesisInfo, err = client.GetGenesis(); err != nil {
+		if genesisInfo, err = client.Genesis(); err != nil {
 			b.Log.WithError(err).
 				WithField("endpoint", client.Endpoint()).
 				Warn("failed to get genesis info")
@@ -274,7 +274,7 @@ func (b *beaconClient) KnownValidators(headSlot Slot) (AllValidatorsResponse, er
 	return vd, err
 }
 
-func (b *beaconClient) GetGenesis() (*GenesisResponse, error) {
+func (b *beaconClient) Genesis() (*GenesisResponse, error) {
 	resp := new(GenesisResponse)
 	u := *b.beaconEndpoint
 	// https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/getSyncingStatus

--- a/pkg/beacon.go
+++ b/pkg/beacon.go
@@ -31,7 +31,7 @@ type BeaconClient interface {
 	GetProposerDuties(Epoch) (*RegisteredProposersResponse, error)
 	SyncStatus() (*SyncStatusPayloadData, error)
 	KnownValidators(Slot) (AllValidatorsResponse, error)
-	Genesis() (*GenesisInfo, error)
+	Genesis() (GenesisInfo, error)
 	Endpoint() string
 }
 
@@ -150,7 +150,7 @@ func (b *MultiBeaconClient) KnownValidators(headSlot Slot) (AllValidatorsRespons
 	return AllValidatorsResponse{}, ErrNodesUnavailable
 }
 
-func (b *MultiBeaconClient) Genesis() (genesisInfo *GenesisInfo, err error) {
+func (b *MultiBeaconClient) Genesis() (genesisInfo GenesisInfo, err error) {
 	clients := b.clientsByLastResponse()
 	for _, client := range clients {
 		if genesisInfo, err = client.Genesis(); err != nil {
@@ -274,13 +274,13 @@ func (b *beaconClient) KnownValidators(headSlot Slot) (AllValidatorsResponse, er
 	return vd, err
 }
 
-func (b *beaconClient) Genesis() (*GenesisInfo, error) {
+func (b *beaconClient) Genesis() (GenesisInfo, error) {
 	resp := new(GenesisResponse)
 	u := *b.beaconEndpoint
 	// https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/getSyncingStatus
 	u.Path = "/eth/v1/beacon/genesis"
 	err := b.queryBeacon(&u, "GET", &resp)
-	return &resp.Data, err
+	return resp.Data, err
 }
 
 func (b *beaconClient) Endpoint() string {

--- a/pkg/datastore_test.go
+++ b/pkg/datastore_test.go
@@ -601,17 +601,20 @@ func validValidatorRegistration(t require.TestingT, domain types.Domain) (*types
 	}, sk
 }
 
-func validSubmitBlockRequest(t require.TestingT, domain types.Domain) *types.BuilderSubmitBlockRequest {
+func validSubmitBlockRequest(t require.TestingT, domain types.Domain, genesisTime uint64) *types.BuilderSubmitBlockRequest {
 	sk, pk, err := bls.GenerateNewKeypair()
 	require.NoError(t, err)
 
 	var pubKey types.PublicKey
 	pubKey.FromSlice(pk.Compress())
 
+	slot := rand.Uint64()
+
 	payload := randomPayload()
+	payload.Timestamp = genesisTime + (slot * 12)
 
 	msg := &types.BidTrace{
-		Slot:                 rand.Uint64(),
+		Slot:                 slot,
 		ParentHash:           payload.ParentHash,
 		BlockHash:            payload.BlockHash,
 		BuilderPubkey:        pubKey,

--- a/pkg/service.go
+++ b/pkg/service.go
@@ -173,7 +173,7 @@ func (s *DefaultService) beaconEventLoop(ctx context.Context, client BeaconClien
 		return ErrBeaconNodeSyncing
 	}
 
-	genesis, err := client.GetGenesis()
+	genesis, err := client.Genesis()
 	if err != nil {
 		return fmt.Errorf("fail to get genesis from beacon: %w", err)
 	}

--- a/pkg/service.go
+++ b/pkg/service.go
@@ -177,9 +177,9 @@ func (s *DefaultService) beaconEventLoop(ctx context.Context, client BeaconClien
 	if err != nil {
 		return fmt.Errorf("fail to get genesis from beacon: %w", err)
 	}
-	s.state.genesis.Store(genesis.Data)
+	s.state.genesis.Store(genesis)
 	s.Log.
-		WithField("genesis-time", time.Unix(int64(genesis.Data.GenesisTime), 0)).
+		WithField("genesis-time", time.Unix(int64(genesis.GenesisTime), 0)).
 		Info("genesis retrieved")
 
 	err = s.updateProposerDuties(ctx, client, Slot(syncStatus.HeadSlot))

--- a/pkg/service.go
+++ b/pkg/service.go
@@ -173,6 +173,15 @@ func (s *DefaultService) beaconEventLoop(ctx context.Context, client BeaconClien
 		return ErrBeaconNodeSyncing
 	}
 
+	genesis, err := client.GetGenesis()
+	if err != nil {
+		return fmt.Errorf("fail to get genesis from beacon: %w", err)
+	}
+	s.state.genesis.Store(genesis.Data)
+	s.Log.
+		WithField("genesis-time", genesis.Data.GenesisTime).
+		Info("genesis retrieved")
+
 	err = s.updateProposerDuties(ctx, client, Slot(syncStatus.HeadSlot))
 	if err != nil {
 		return err
@@ -498,6 +507,7 @@ type atomicState struct {
 	datastore  atomic.Value
 	duties     atomic.Value
 	validators atomic.Value
+	genesis    atomic.Value
 }
 
 func (as *atomicState) Datastore() Datastore { return as.datastore.Load().(Datastore) }
@@ -505,12 +515,14 @@ func (as *atomicState) Datastore() Datastore { return as.datastore.Load().(Datas
 func (as *atomicState) Beacon() BeaconState {
 	duties := as.duties.Load().(dutiesState)
 	validators := as.validators.Load().(validatorsState)
-	return beaconState{dutiesState: duties, validatorsState: validators}
+	genesis := as.validators.Load().(GenesisInfo)
+	return beaconState{dutiesState: duties, validatorsState: validators, GenesisInfo: genesis}
 }
 
 type beaconState struct {
 	dutiesState
 	validatorsState
+	GenesisInfo
 }
 
 func (s beaconState) KnownValidatorByIndex(index uint64) (types.PubkeyHex, error) {
@@ -536,6 +548,10 @@ func (s beaconState) HeadSlot() Slot {
 
 func (s beaconState) ValidatorsMap() BuilderGetValidatorsResponseEntrySlice {
 	return s.proposerDutiesResponse
+}
+
+func (s beaconState) Genesis() GenesisInfo {
+	return s.GenesisInfo
 }
 
 type dutiesState struct {

--- a/pkg/service.go
+++ b/pkg/service.go
@@ -515,7 +515,7 @@ func (as *atomicState) Datastore() Datastore { return as.datastore.Load().(Datas
 func (as *atomicState) Beacon() BeaconState {
 	duties := as.duties.Load().(dutiesState)
 	validators := as.validators.Load().(validatorsState)
-	genesis := as.validators.Load().(GenesisInfo)
+	genesis := as.genesis.Load().(GenesisInfo)
 	return beaconState{dutiesState: duties, validatorsState: validators, GenesisInfo: genesis}
 }
 

--- a/pkg/service.go
+++ b/pkg/service.go
@@ -179,7 +179,7 @@ func (s *DefaultService) beaconEventLoop(ctx context.Context, client BeaconClien
 	}
 	s.state.genesis.Store(genesis.Data)
 	s.Log.
-		WithField("genesis-time", genesis.Data.GenesisTime).
+		WithField("genesis-time", time.Unix(int64(genesis.Data.GenesisTime), 0)).
 		Info("genesis retrieved")
 
 	err = s.updateProposerDuties(ctx, client, Slot(syncStatus.HeadSlot))

--- a/pkg/service_test.go
+++ b/pkg/service_test.go
@@ -166,7 +166,7 @@ func TestBeaconClientState(t *testing.T) {
 		},
 	)
 	beaconMock.EXPECT().KnownValidators(gomock.Any()).Return(relay.AllValidatorsResponse{Data: []relay.ValidatorResponseEntry{}}, nil).Times(1)
-	beaconMock.EXPECT().Genesis().Times(1).Return(&relay.GenesisResponse{}, nil)
+	beaconMock.EXPECT().Genesis().Times(1).Return(&relay.GenesisInfo{}, nil)
 
 	var wg sync.WaitGroup
 	defer wg.Wait()

--- a/pkg/service_test.go
+++ b/pkg/service_test.go
@@ -166,7 +166,7 @@ func TestBeaconClientState(t *testing.T) {
 		},
 	)
 	beaconMock.EXPECT().KnownValidators(gomock.Any()).Return(relay.AllValidatorsResponse{Data: []relay.ValidatorResponseEntry{}}, nil).Times(1)
-	beaconMock.EXPECT().GetGenesis().Times(1).Return(&relay.GenesisResponse{}, nil)
+	beaconMock.EXPECT().Genesis().Times(1).Return(&relay.GenesisResponse{}, nil)
 
 	var wg sync.WaitGroup
 	defer wg.Wait()

--- a/pkg/service_test.go
+++ b/pkg/service_test.go
@@ -166,7 +166,7 @@ func TestBeaconClientState(t *testing.T) {
 		},
 	)
 	beaconMock.EXPECT().KnownValidators(gomock.Any()).Return(relay.AllValidatorsResponse{Data: []relay.ValidatorResponseEntry{}}, nil).Times(1)
-	beaconMock.EXPECT().Genesis().Times(1).Return(&relay.GenesisInfo{}, nil)
+	beaconMock.EXPECT().Genesis().Times(1).Return(relay.GenesisInfo{}, nil)
 
 	var wg sync.WaitGroup
 	defer wg.Wait()

--- a/pkg/service_test.go
+++ b/pkg/service_test.go
@@ -166,6 +166,7 @@ func TestBeaconClientState(t *testing.T) {
 		},
 	)
 	beaconMock.EXPECT().KnownValidators(gomock.Any()).Return(relay.AllValidatorsResponse{Data: []relay.ValidatorResponseEntry{}}, nil).Times(1)
+	beaconMock.EXPECT().GetGenesis().Times(1).Return(&relay.GenesisResponse{}, nil)
 
 	var wg sync.WaitGroup
 	defer wg.Wait()


### PR DESCRIPTION
# What 🕵️‍♀️
It is necessary to check whether the timestamp of the block submissions is the one expected for the corresponding slot. 

# Why 🔑
If validation is not implemented, then (correctly implemented) validators to reject the blocks the relay serves them.

# How ⚙️
Obtain Genesis time on relay initialization and compute expected timestamp on block submissions by doing `genesisTime + slot x 12`

# Testing 🧪
- [x] add tests to check timestamp validation
- [x] `go test -race ./...` from root
- [x] end-to-end testing in testnet 

# Special mentions
Thank you to @metachris for notifying about this, and help make the relay more robust.