### PR TITLE
Set JSON timestamp to RFC3339Nano.

### DIFF
--- a/cmd/dreamboat/main.go
+++ b/cmd/dreamboat/main.go
@@ -101,7 +101,7 @@ var flags = []cli.Flag{
 }
 
 var (
-	config = relay.Config{Log: log.New()}
+	config relay.Config
 	svr    http.Server
 )
 
@@ -117,7 +117,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		config.Log.Fatal(err)
+		log.Fatal(err)
 	}
 }
 
@@ -275,7 +275,11 @@ func withFormat(c *cli.Context) log.Option {
 	switch c.String("logfmt") {
 	case "none":
 	case "json":
-		fmt = &logrus.JSONFormatter{PrettyPrint: c.Bool("prettyprint")}
+		fmt = &logrus.JSONFormatter{
+			PrettyPrint:     c.Bool("prettyprint"),
+			TimestampFormat: time.RFC3339Nano,
+		}
+
 	default:
 		fmt = new(logrus.TextFormatter)
 	}


### PR DESCRIPTION
Adds nanosecond precision to logs (JSON format only).

cc @bkellerman: for context, and in case you ever need to fix this somewhere else