### PR TITLE
verify fee recipient of submitted block

### DIFF
--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -539,7 +539,7 @@ func (rs *DefaultRelay) verifyBlock(ctx context.Context, SubmitBlockRequest *typ
 	reg, err := state.Datastore().GetRegistration(ctx, pubKey)
 	if err != nil {
 		if !errors.Is(err, ds.ErrNotFound) {
-			rs.Log().Warn("unexpected datastore error")
+			rs.Log().WithError(err).Warn("unexpected datastore error")
 		}
 		return false, ErrUnregisteredSlot
 	}


### PR DESCRIPTION
# What 🕵️‍♀️
Explain what this PR accomplishes

Adds a check to verify that a block submissions proposer fee recipient matches the fee recipient validators have registered. Thanks to @metachris for pointing this out!

# Why 🔑
Explain the need or decisions which make this change necessary

Currently dreamboat does not support external builders, but instead a loosely defined trusted builder. We are in the process of hardening to be able to support any external builder with hopefully 0 trust.

# How ⚙️
Briefly explain what components you modified or added, and how, to give context to your reviewers

On block submission we grab the validators registered fee recipient and compare it to the value in the block.

# Testing 🧪
- [ ] `go test -race ./...` from root
