### PR TITLE
fix submitBlock default error

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -217,7 +217,7 @@ func (a *API) submitBlock(w http.ResponseWriter, r *http.Request) (int, error) {
 	var req types.BuilderSubmitBlockRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		a.m.ApiReqCounter.WithLabelValues("submitBlock", "400", "payload decode").Inc()
-		return http.StatusBadRequest, err
+		return http.StatusBadRequest, errors.New("invalid payload")
 	}
 
 	if req.ExecutionPayload != nil && req.ExecutionPayload.Transactions != nil {


### PR DESCRIPTION
# What 🕵️‍♀️
Explain what this PR accomplishes

"Manually fuzz testing" and noticed submitBlock returns errors like:
```
{"code":400,"message":"EOF"}
```
when it should be 
```
{"code":400,"message":"EOF"}
```
like the other endpoints

# Why 🔑
Explain the need or decisions which make this change necessary

API consistency

# Testing 🧪
- [x] `go test -race ./...` from root
