### PR TITLE
only log successful registrations

### DIFF
--- a/pkg/relay/register.go
+++ b/pkg/relay/register.go
@@ -109,9 +109,12 @@ SendPayloads:
 
 	err := <-fc.ExitCh
 
-	logger.
-		WithField("processingTimeMs", time.Since(timeStart).Milliseconds()).
-		Trace("validator registrations succeeded")
+	if err != nil {
+		logger.
+			WithField("processingTimeMs", time.Since(timeStart).Milliseconds()).
+			WithField("numberValidators", len(payload)).
+			Trace("validator registrations succeeded")
+	}
 
 	return err
 }

--- a/pkg/relay/register.go
+++ b/pkg/relay/register.go
@@ -109,7 +109,7 @@ SendPayloads:
 
 	err := <-fc.ExitCh
 
-	if err != nil {
+	if err == nil {
 		logger.
 			WithField("processingTimeMs", time.Since(timeStart).Milliseconds()).
 			WithField("numberValidators", len(payload)).


### PR DESCRIPTION
# What 🕵️‍♀️
This PR fixes how the validator registrations are logged

# Why 🔑
Otherwise there are inconsistencies on how previously registrations were logged

# Testing 🧪
- [x] `go test -race ./...` from root
