### PR TITLE
Fix registerValidator/all metric

### DIFF
--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -70,7 +70,7 @@ func (rs *Register) RegisterValidator(ctx context.Context, m *structs.MetricGrou
 	logger := rs.l.WithField("method", "RegisterValidator")
 
 	tStart := time.Now()
-	m.AppendSince(tStart, "registerValidator", "all")
+	defer m.AppendSince(tStart, "registerValidator", "all")
 
 	be := rs.beaconState.Beacon()
 


### PR DESCRIPTION
# What 🕵️‍♀️
Fixes the observing of the metric `registerValidator-all`

# Why 🔑
Otherwise we don't get real numbers on the time it takes to process registrations

# How ⚙️
Add a `defer`, in order to observe after the function is finished

# Testing 🧪
- [ ] `go test -race ./...` from root
