### PR TITLE
unwrap error for metrics

### DIFF
--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -25,13 +25,12 @@ type Verifier interface {
 }
 
 var (
-	ErrNoPayloadFound        = errors.New("no payload found")
-	ErrMissingRequest        = errors.New("req is nil")
-	ErrMissingSecretKey      = errors.New("secret key is nil")
-	UnregisteredValidatorMsg = "unregistered validator"
-	ErrNoBuilderBid          = errors.New("no builder bid")
-	ErrOldSlot               = errors.New("requested slot is old")
-	ErrBadHeader             = "invalid block header from datastore"
+	ErrNoPayloadFound   = errors.New("no payload found")
+	ErrMissingRequest   = errors.New("req is nil")
+	ErrMissingSecretKey = errors.New("secret key is nil")
+	ErrNoBuilderBid     = errors.New("no builder bid")
+	ErrOldSlot          = errors.New("requested slot is old")
+	ErrBadHeader        = errors.New("invalid block header from datastore")
 )
 
 type Datastore interface {
@@ -155,7 +154,7 @@ func (rs *Relay) GetHeader(ctx context.Context, m *structs.MetricGroup, request 
 	header := maxProfitBlock.Header
 
 	if header.Header == nil || (header.Header.ParentHash != parentHash) {
-		logger.Debug(ErrBadHeader)
+		logger.Debug(ErrBadHeader.Error())
 		rs.m.MissHeaderCount.WithLabelValues("badHeader").Add(1)
 		return nil, ErrNoBuilderBid
 	}


### PR DESCRIPTION
# What 🕵️‍♀️
Fix the error label for relay metrics

# Why 🔑
Currently, the errors that relay generates have unique strings, because the error states the exact validator, slot, etc. that caused the error. But, we need a limited and constant set of error messages, otherwise the visualization filtered by errors is not useful.

# How ⚙️
Unwrap the error and unifiy unique messages into higher-level generic messages.

# Testing 🧪
- [ ] `go test -race ./...` from root
