### PR TITLE
Feature/fast boot

### DIFF
--- a/cmd/dreamboat/main.go
+++ b/cmd/dreamboat/main.go
@@ -174,6 +174,12 @@ var flags = []cli.Flag{
 		Value:   false,
 		EnvVars: []string{"RELAY_PUBLISH_BLOCK"},
 	},
+	&cli.BoolFlag{
+		Name:    "relay-fast-boot",
+		Usage:   "speed up booting up of relay, adding temporary inconsistency on the builder_blocks_received endpoint",
+		Value:   false,
+		EnvVars: []string{"RELAY_FAST_BOOT"},
+	},
 }
 
 var (
@@ -291,8 +297,21 @@ func run() cli.ActionFunc {
 			return err
 		}
 
-		if err = ds.FixOrphanHeaders(c.Context, config.TTL); err != nil {
-			return err
+		errCh := make(chan error, 1)
+
+		go func(ctx context.Context, l log.Logger) {
+			if err := ds.FixOrphanHeaders(ctx, config.TTL); err != nil {
+				l.WithError(err).Error("fail to fix orphan headers")
+			} else {
+				l.Info("fixed orphan headers")
+			}
+			errCh <- err
+		}(c.Context, config.Log)
+
+		if !c.Bool("relay-fast-boot") {
+			if err := <-errCh; err != nil {
+				return fmt.Errorf("fail to fix orphan headers: %w", err)
+			}
 		}
 
 		go ds.MemoryCleanup(c.Context, config.RelayHeaderMemoryPurgeInterval, config.TTL)
@@ -322,7 +341,9 @@ func run() cli.ActionFunc {
 			return fmt.Errorf("fail to initialize store manager: %w", err)
 		}
 		regStr.AttachMetrics(m)
-		loadRegistrations(ds, regStr, logger)
+		if !c.Bool("relay-fast-boot") {
+			loadRegistrations(ds, regStr, logger)
+		}
 		go regStr.RunCleanup(uint64(config.TTL), time.Hour)
 
 		regM := validators.NewRegister(config.Log, domainBuilder, as, v, regStr, ds)

--- a/cmd/dreamboat/main.go
+++ b/cmd/dreamboat/main.go
@@ -258,7 +258,7 @@ func run() cli.ActionFunc {
 			return err
 		}
 
-		logger := config.Log
+		logger := config.Log.WithField("fast-boot", c.Bool("relay-fast-boot"))
 
 		domainBuilder, err := pkg.ComputeDomain(types.DomainTypeAppBuilder, config.GenesisForkVersion, types.Root{}.String())
 		if err != nil {


### PR DESCRIPTION
# What 🕵️‍♀️
Adds a flag to speed up the booting up of the relay in exchange for adding temporary inconsistency on the builder_blocks_received endpoint, as well as not loading validator registrations to the cache

# Why 🔑
This avoids slow booting up when the local DB (e.g. badgerdb) is very big

# Testing 🧪
- [ ] `go test -race ./...` from root
