### PR TITLE
Change beacon log time precision to ms

### DIFF
--- a/pkg/service.go
+++ b/pkg/service.go
@@ -119,7 +119,7 @@ func (s *Service) RunBeacon(ctx context.Context, client BeaconClient) error {
 				"numDuties":                 len(duties),
 				"numKnownValidators":        len(validators),
 				"knownValidatorsUpdateTime": s.knownValidatorsUpdateTime(),
-				"processingTimeMs":          time.Since(t),
+				"processingTimeMs":          time.Since(t).Milliseconds(),
 			}).Debug("processed new slot")
 		}
 	}


### PR DESCRIPTION
# What 🕵️‍♀️
Fix time precision to be milliseconds in the beacon state loop.

# Why 🔑
Otherwise, you cannot visualize this metric with other processing times, since they have different precisions

