### PR TITLE
PublishBlock before storing "payload delivery" in data API

### DIFF
--- a/pkg/beacon.go
+++ b/pkg/beacon.go
@@ -320,6 +320,9 @@ func (b *beaconClient) PublishBlock(block *types.SignedBeaconBlock) error {
 		return fmt.Errorf("fail to marshal block: %w", err)
 	}
 
+	t := prometheus.NewTimer(b.m.Timing.WithLabelValues(b.beaconEndpoint.String() + "/eth/v1/beacon/blocks"))
+	defer t.ObserveDuration()
+
 	resp, err := http.Post(b.beaconEndpoint.String()+"/eth/v1/beacon/blocks", "application/json", bytes.NewBuffer(bb))
 	if err != nil {
 		return fmt.Errorf("fail to publish block: %w", err)

--- a/pkg/beacon.go
+++ b/pkg/beacon.go
@@ -320,7 +320,7 @@ func (b *beaconClient) PublishBlock(block *types.SignedBeaconBlock) error {
 		return fmt.Errorf("fail to marshal block: %w", err)
 	}
 
-	t := prometheus.NewTimer(b.m.Timing.WithLabelValues("/eth/v1/beacon/blocks"))
+	t := prometheus.NewTimer(b.m.Timing.WithLabelValues("/eth/v1/beacon/blocks", "POST"))
 	defer t.ObserveDuration()
 
 	resp, err := http.Post(b.beaconEndpoint.String()+"/eth/v1/beacon/blocks", "application/json", bytes.NewBuffer(bb))
@@ -359,7 +359,7 @@ func (b *beaconClient) initMetrics() {
 		Subsystem: "beacon",
 		Name:      "timing",
 		Help:      "Duration of requests per endpoint",
-	}, []string{"endpoint"})
+	}, []string{"endpoint", "method"})
 }
 
 func (b *beaconClient) AttachMetrics(m *metrics.Metrics) {
@@ -373,7 +373,7 @@ func (b *beaconClient) queryBeacon(u *url.URL, method, pathName string, dst any)
 	}
 	req.Header.Set("accept", "application/json")
 
-	t := prometheus.NewTimer(b.m.Timing.WithLabelValues(pathName))
+	t := prometheus.NewTimer(b.m.Timing.WithLabelValues(pathName, method))
 	defer t.ObserveDuration()
 
 	resp, err := http.DefaultClient.Do(req)

--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -283,7 +283,7 @@ func (rs *Relay) GetPayload(ctx context.Context, m *structs.MetricGroup, payload
 			}
 		}
 
-		if err := rs.d.PutDelivered(ctx, slot, trace, rs.config.TTL); err != nil {
+		if err := rs.d.PutDelivered(context.Background(), slot, trace, rs.config.TTL); err != nil {
 			logger.WithError(err).Warn("failed to set payload after delivery")
 		}
 	}(rs, structs.Slot(payloadRequest.Message.Slot), trace)

--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -274,10 +274,6 @@ func (rs *Relay) GetPayload(ctx context.Context, m *structs.MetricGroup, payload
 
 	// defer put delivered datastore write
 	go func(rs *Relay, slot structs.Slot, trace structs.DeliveredTrace) {
-		if err := rs.d.PutDelivered(ctx, slot, trace, rs.config.TTL); err != nil {
-			logger.WithError(err).Warn("failed to set payload after delivery")
-		}
-
 		if rs.config.PublishBlock {
 			beaconBlock := structs.SignedBlindedBeaconBlockToBeaconBlock(payloadRequest, payload.Payload.Data)
 			if err := rs.beacon.PublishBlock(beaconBlock); err != nil {
@@ -285,6 +281,10 @@ func (rs *Relay) GetPayload(ctx context.Context, m *structs.MetricGroup, payload
 			} else {
 				logger.Info("published block to beacon node")
 			}
+		}
+
+		if err := rs.d.PutDelivered(ctx, slot, trace, rs.config.TTL); err != nil {
+			logger.WithError(err).Warn("failed to set payload after delivery")
 		}
 	}(rs, structs.Slot(payloadRequest.Message.Slot), trace)
 


### PR DESCRIPTION
# What 🕵️‍♀️
This PR moves the PublishBlock call to before PutDelivered, in order to speed up as much as possible.

# Why 🔑
If the Storage is congested, then the PublishBlock will take too much time.
