### PR TITLE
Fix/trace timestamp

### DIFF
--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -459,7 +459,8 @@ func (rs *Relay) prepareContents(submitBlockRequest *types.BuilderSubmitBlockReq
 				BlockNumber: s.Payload.Payload.Data.BlockNumber,
 				NumTx:       uint64(len(s.Payload.Payload.Data.Transactions)),
 			},
-			Timestamp: s.Payload.Payload.Data.Timestamp,
+			Timestamp: uint64(time.Now().Second()),
+			TimestampMs: uint64(time.Now().UnixMilli()),
 		},
 	}
 

--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -459,7 +459,7 @@ func (rs *Relay) prepareContents(submitBlockRequest *types.BuilderSubmitBlockReq
 				BlockNumber: s.Payload.Payload.Data.BlockNumber,
 				NumTx:       uint64(len(s.Payload.Payload.Data.Transactions)),
 			},
-			Timestamp: uint64(time.Now().Second()),
+			Timestamp:   uint64(time.Now().UnixMilli() / 1_000),
 			TimestampMs: uint64(time.Now().UnixMilli()),
 		},
 	}

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -126,7 +126,8 @@ type BidTraceExtended struct {
 
 type BidTraceWithTimestamp struct {
 	BidTraceExtended
-	Timestamp uint64 `json:"timestamp,string"`
+	Timestamp   uint64 `json:"timestamp,string"`
+	TimestampMs uint64 `json:"timestamp_ms,string"`
 }
 
 type BuilderGetValidatorsResponseEntrySlice []types.BuilderGetValidatorsResponseEntry


### PR DESCRIPTION
# What 🕵️‍♀️
Adds Timestamp and TimestampMs to builder block submission data API

# Why 🔑
So that external observers can have greater insights on block submissions
