### PR TITLE
Add log to record invalid parenthash

### DIFF
--- a/pkg/relay/relay.go
+++ b/pkg/relay/relay.go
@@ -186,7 +186,9 @@ func (rs *Relay) GetHeader(ctx context.Context, m *structs.MetricGroup, request 
 	header := maxProfitBlock.Header
 
 	if header.Header == nil || (header.Header.ParentHash != parentHash) {
-		logger.Debug(ErrBadHeader.Error())
+		if header.Header.ParentHash != parentHash {
+			logger.WithField("expected", parentHash).WithField("got", parentHash).Debug("invalid parentHash")
+		}
 		rs.m.MissHeaderCount.WithLabelValues("badHeader").Add(1)
 		return nil, ErrNoBuilderBid
 	}


### PR DESCRIPTION
# What 🕵️‍♀️
Adds a log statement to record whenever an invalid parenthash is requested on GetHeader

# Why 🔑
This way we can debug if we fail to deliver bids due to invalid parenthash

