### PR TITLE
Force beacon reconnect

### DIFF
--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	beaconEventTick = structs.DurationPerSlot * 2
+	beaconEventTimeout = structs.DurationPerSlot * 2
 )
 
 var (
@@ -61,10 +61,10 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 			go b.runNewHeadSubscriptionLoop(loopCtx, logger, slotC, newEvent)
 
 			for {
-				timer := time.NewTimer(beaconEventTick)
+				timer := time.NewTimer(beaconEventTimeout)
 				select {
 				case <-newEvent:
-					timer.Reset(beaconEventTick)
+					timer.Reset(beaconEventTimeout)
 					continue
 				case <-timer.C:
 					logger.Warn("timed out head events subscription, restarting..")

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	beaconEventTick = structs.DurationPerSlot + (structs.DurationPerSlot / 2)
+	beaconEventTick = structs.DurationPerSlot * 2
 )
 
 var (

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -52,7 +52,7 @@ func NewBeaconClient(l log.Logger, endpoint string) (*beaconClient, error) {
 }
 
 func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan HeadEvent) {
-	logger := b.log.WithField("method", "SubscribeToHeadEvents")\
+	logger := b.log.WithField("method", "SubscribeToHeadEvents")
 	defer logger.Debug("head events subscription stopped")
 
 	for {
@@ -76,7 +76,7 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 }
 
 func (b *beaconClient) runNewHeadSubscriptionLoop(ctx context.Context, logger log.Logger, timer *time.Timer, slotC chan<- HeadEvent) {
-	
+
 	for {
 		client := sse.NewClient(fmt.Sprintf("%s/eth/v1/events?topics=head", b.beaconEndpoint.String()))
 		err := client.SubscribeRawWithContext(ctx, func(msg *sse.Event) {

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -76,6 +76,7 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 }
 
 func (b *beaconClient) runNewHeadSubscriptionLoop(ctx context.Context, logger log.Logger, timer *time.Timer, slotC chan<- HeadEvent) {
+	defer logger.Warn("subscription loop exited")
 
 	for {
 		client := sse.NewClient(fmt.Sprintf("%s/eth/v1/events?topics=head", b.beaconEndpoint.String()))

--- a/beacon/manager.go
+++ b/beacon/manager.go
@@ -19,8 +19,6 @@ const (
 )
 
 var (
-	DurationPerSlot  = time.Second * 12
-	DurationPerEpoch = DurationPerSlot * time.Duration(structs.SlotsPerEpoch)
 	ErrUnkownFork    = errors.New("beacon node fork is unknown")
 )
 
@@ -253,7 +251,7 @@ func (s *Manager) processNewSlot(ctx context.Context, state State, client Beacon
 	headSlot = received
 
 	// update proposer duties and known validators in the background
-	if (DurationPerEpoch / 2) < time.Since(state.KnownValidatorsUpdateTime()) { // only update every half DurationPerEpoch
+	if (structs.DurationPerEpoch / 2) < time.Since(state.KnownValidatorsUpdateTime()) { // only update every half DurationPerEpoch
 		go func(slot structs.Slot) {
 			if err := s.updateKnownValidators(ctx, state, client, slot); err != nil {
 				logger.WithError(err).Error("failed to update known validators")

--- a/cmd/dreamboat/main.go
+++ b/cmd/dreamboat/main.go
@@ -314,7 +314,7 @@ func run() cli.ActionFunc {
 			return fmt.Errorf("fail to create datastore: %w", err)
 		}
 
-		beaconCli, err := initBeaconClients(c.Context, logger, c.StringSlice("beacon"), m)
+		beaconCli, err := initBeaconClients(logger, c.StringSlice("beacon"), m)
 		if err != nil {
 			return fmt.Errorf("fail to initialize beacon: %w", err)
 		}
@@ -562,7 +562,7 @@ func preloadValidators(ctx context.Context, l log.Logger, vs ValidatorStore, vc 
 	l.With(log.F{"count": vc.Len()}).Info("Loaded cache validators")
 }
 
-func initBeaconClients(ctx context.Context, l log.Logger, endpoints []string, m *metrics.Metrics) (*bcli.MultiBeaconClient, error) {
+func initBeaconClients(l log.Logger, endpoints []string, m *metrics.Metrics) (*bcli.MultiBeaconClient, error) {
 	clients := make([]bcli.BeaconNode, 0, len(endpoints))
 
 	for _, endpoint := range endpoints {

--- a/structs/const.go
+++ b/structs/const.go
@@ -1,5 +1,11 @@
 package structs
 
+import (
+	"time"
+)
+
 const (
-	SlotsPerEpoch Slot = 32
+	SlotsPerEpoch    Slot = 32
+	DurationPerSlot       = time.Second * 12
+	DurationPerEpoch      = DurationPerSlot * time.Duration(SlotsPerEpoch)
 )


### PR DESCRIPTION
# What 🕵️‍♀️
This PR checks whether the beacon nodes subscription to head events does not produce any event for more than two slots, and if so, it restarts the subscription.

# Why 🔑
Beacon node subscriptions are unstable, and we have detected that they do not produce any event for a long time, consequently desynchronizing the relay.
