### PR TITLE
move timer reset

### DIFF
--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -84,13 +84,16 @@ func (b *beaconClient) runNewHeadSubscriptionLoop(ctx context.Context, logger lo
 			var head HeadEvent
 			if err := json.Unmarshal(msg.Data, &head); err != nil {
 				logger.WithError(err).Warn("event subscription failed")
+				return
 			}
 
+			timer.Reset(BeaconEventTimeout)
+
 			select {
-			case <-ctx.Done():
-				return
 			case slotC <- head:
-				timer.Reset(BeaconEventTimeout)
+			case <-time.After(structs.DurationPerSlot / 2): // relief pressure if
+				logger.WithField("timemout", structs.DurationPerSlot/2).Warn("timeout waiting to consume head event")
+			case <-ctx.Done():
 			}
 		})
 

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -92,7 +92,7 @@ func (b *beaconClient) runNewHeadSubscriptionLoop(ctx context.Context, logger lo
 			select {
 			case slotC <- head:
 			case <-time.After(structs.DurationPerSlot / 2): // relief pressure if
-				logger.WithField("timemout", structs.DurationPerSlot/2).Warn("timeout waiting to consume head event")
+				logger.WithField("timeout", structs.DurationPerSlot/2).Warn("timeout waiting to consume head event")
 			case <-ctx.Done():
 			}
 		})

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -93,7 +93,9 @@ func (b *beaconClient) runNewHeadSubscriptionLoop(ctx context.Context, logger lo
 			case slotC <- head:
 			case <-time.After(structs.DurationPerSlot / 2): // relief pressure if
 				logger.WithField("timeout", structs.DurationPerSlot/2).Warn("timeout waiting to consume head event")
+				return
 			case <-ctx.Done():
+				return
 			}
 		})
 


### PR DESCRIPTION
# What 🕵️‍♀️
This PR improves new head events subscriptions so that it does not close the subscription unless there is not an event. Previously it closed also if event consumption was taking too much time. However, this has nothing to do with connection reset.
