### PR TITLE
Add logic to manually fetch header if subscription fails

### DIFF
--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -367,7 +367,7 @@ func (h HeadEvent) Loggable() map[string]any {
 
 // Header is the block header from the beacon chain
 type Message struct {
-	Slot          uint64 `json:"slot"`
+	Slot          uint64 `json:"slot,string"`
 	ProposerIndex string `json:"proposer_index"`
 	ParentRoot    string `json:"parent_root"`
 	StateRoot     string `json:"state_root"`

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -71,8 +71,8 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 					header, err := b.queryLatestHeader()
 					if err != nil {
 						logger.WithError(err).Warn("failed querying latest header manually")
-					} else if len(header.Data) != 0 {
-						logger.Warn("failed to query latest header manually, unexpected amount of header: expected 1 - got %d", len(header.Data))
+					} else if len(header.Data) != 1 {
+						logger.Warnf("failed to query latest header manually, unexpected amount of header: expected 1 - got %d", len(header.Data))
 					}
 
 					// send slot to beacon manager to consume async

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -103,7 +103,7 @@ func (b *beaconClient) runNewHeadSubscriptionLoop(ctx context.Context, logger lo
 
 			select {
 			case slotC <- head:
-			case <-time.After(structs.DurationPerSlot / 2): // relief pressure if
+			case <-time.After(structs.DurationPerSlot / 2): // relief pressure
 				logger.WithField("timeout", structs.DurationPerSlot/2).Warn("timeout waiting to consume head event")
 				return
 			case <-ctx.Done():
@@ -138,7 +138,7 @@ func (b *beaconClient) manuallyFetchLatestHeader(ctx context.Context, logger log
 	select {
 	case slotC <- event:
 		return
-	case <-time.After(structs.DurationPerSlot):
+	case <-time.After(structs.DurationPerSlot / 2):
 		logger.WithField("timeout", structs.DurationPerSlot/2).Warn("timeout waiting to consume head event after manual querying")
 		return
 	case <-ctx.Done():

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -87,6 +87,7 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 }
 
 func (b *beaconClient) runNewHeadSubscriptionLoop(ctx context.Context, logger log.Logger, timer *time.Timer, slotC chan<- HeadEvent) {
+	logger.Debug("subscription loop started")
 	defer logger.Warn("subscription loop exited")
 
 	for {

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -60,7 +60,7 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 		timer := time.NewTimer(BeaconEventTimeout)
 		go b.runNewHeadSubscriptionLoop(loopCtx, logger, timer, slotC)
 
-		lastTimeout := time.Now().Add(-(BeaconEventTimeout * 2)) //
+		lastTimeout := time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC) // zeroed value time.Time
 	EventSelect:
 		for {
 			select {

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -66,19 +66,19 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 			case <-timer.C:
 				logger.Warn("timed out head events subscription, restarting and manually querying latest header")
 
-				// fetch head slot manully
-				header, err := b.queryLatestHeader()
-				if err != nil {
-					logger.WithError(err).Warn("failed querying latest header manually")
-				} else if len(header.Data) != 0 {
-					logger.Warn("failed to query latest header manually, unexpected amount of header: expected 1 - got %d", len(header.Data))
-				}
-
-				// send slot to beacon manager to consume async
 				go func() {
+					// fetch head slot manully
+					header, err := b.queryLatestHeader()
+					if err != nil {
+						logger.WithError(err).Warn("failed querying latest header manually")
+					} else if len(header.Data) != 0 {
+						logger.Warn("failed to query latest header manually, unexpected amount of header: expected 1 - got %d", len(header.Data))
+					}
+
+					// send slot to beacon manager to consume async
 					event := HeadEvent{Slot: header.Data[0].Header.Message.Slot}
 					logger.With(event).Debug("manually fetched latest beacon header")
-					
+
 					select {
 					case slotC <- event:
 					case <-time.After(structs.DurationPerSlot):

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -60,7 +60,7 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 		timer := time.NewTimer(BeaconEventTimeout)
 		go b.runNewHeadSubscriptionLoop(loopCtx, logger, timer, slotC)
 
-		lastTimeout := time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC) // zeroed value time.Time
+		lastTimeout := time.Time{} // zeroed value time.Time
 	EventSelect:
 		for {
 			select {

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -74,10 +74,10 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 				if time.Since(lastTimeout) <= BeaconEventTimeout*2 {
 					cancelLoop()
 					break EventSelect
-				} else {
-					lastTimeout = time.Now()
-					timer.Reset(BeaconEventTimeout)
 				}
+				lastTimeout = time.Now()
+				timer.Reset(BeaconEventTimeout)
+
 			case <-ctx.Done():
 				cancelLoop()
 				return

--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -147,10 +147,9 @@ func (b *beaconClient) manuallyFetchLatestHeader(ctx context.Context, logger log
 	}
 }
 
-// Returns proposer duties for every slot in this epoch
+// Returns the latest header from the beacon chain
 func (b *beaconClient) queryLatestHeader() (*HeaderRootObject, error) {
 	u := *b.beaconEndpoint
-	// https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDuties
 	u.Path = fmt.Sprintf("/eth/v1/beacon/headers")
 	resp := new(HeaderRootObject)
 


### PR DESCRIPTION
# What 🕵️‍♀️
This PR implements the logic to manually fetch the latest header in case the subscription fails to receive the event

# Why 🔑
This way, we do not always need to rely on the subscription. If it fails, we have a mechanism to fetch it manually, and keep the relay synced

