### PR TITLE
add 20 seconds timeout to all beacon queries

### DIFF
--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	BeaconEventTimeout = structs.DurationPerSlot * 2
+	BeaconQueryTimeout = 20 * time.Second
 )
 
 var (
@@ -264,7 +265,10 @@ func (b *beaconClient) AttachMetrics(m *metrics.Metrics) {
 }
 
 func (b *beaconClient) queryBeacon(u *url.URL, method string, dst any) error {
-	req, err := http.NewRequest(method, u.String(), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), BeaconQueryTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("invalid request for %s: %w", u, err)
 	}


### PR DESCRIPTION
# What 🕵️‍♀️
Add timeouts to all beacon queries 

# Why 🔑
This way we make sure we do not congest either the relay or the beacon with a lot of open connections, in case something goes wrong with the beacon client. The motivation is that we have seen beacon being unresponsive and taking an extremely long time to respond to queries.
