### PR TITLE
Improve beacon subscription restart and logs

### DIFF
--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -76,7 +76,7 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 				if time.Since(lastTimeout) <= BeaconEventTimeout*2 {
 					timeoutCounter++
 					if timeoutCounter >= BeaconConsecutiveTimeout {
-						logger.WithField("timeoutCounter", timeoutCounter).Debug("restarting subcription")
+						logger.WithField("timeoutCounter", timeoutCounter).Warn("restarting subcription")
 						cancelLoop()
 						break EventSelect
 					}

--- a/beacon/manager.go
+++ b/beacon/manager.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	ErrUnkownFork    = errors.New("beacon node fork is unknown")
+	ErrUnkownFork = errors.New("beacon node fork is unknown")
 )
 
 type Datastore interface {
@@ -243,7 +243,7 @@ func (s *Manager) processNewSlot(ctx context.Context, state State, client Beacon
 
 	if headSlot > 0 {
 		for slot := headSlot + 1; slot < received; slot++ {
-			s.Log.Warnf("missedSlot %d", slot)
+			s.Log.With(log.F{"slot": slot, "event": "missed_slot"}).Warn("missed slot")
 		}
 	}
 


### PR DESCRIPTION
# What 🕵️‍♀️
This PR improves logic for beacon subscription restart so that it checks whether there are 3 consecutive timeouts. If they are not consecutive and close in time, then it does not restart, it only fetches the latest header manually.

# Why 🔑
This avoids overly restarting subscriptions in networks like Goerli, where there are many missed slots per epoch.
