### PR TITLE
Increase 'beacon-event-restart' from 3 to 5

### DIFF
--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -103,7 +103,7 @@ func (b *beaconClient) SubscribeToHeadEvents(ctx context.Context, slotC chan Hea
 
 func (b *beaconClient) runNewHeadSubscriptionLoop(ctx context.Context, logger log.Logger, timer *time.Timer, slotC chan<- HeadEvent) {
 	logger.Debug("subscription loop started")
-	defer logger.Warn("subscription loop exited")
+	defer logger.Debug("subscription loop exited")
 
 	for {
 		client := sse.NewClient(fmt.Sprintf("%s/eth/v1/events?topics=head", b.beaconEndpoint.String()))

--- a/cmd/dreamboat/main.go
+++ b/cmd/dreamboat/main.go
@@ -267,7 +267,7 @@ var flags = []cli.Flag{
 	&cli.IntFlag{
 		Name:    "beacon-event-restart",
 		Usage:   "The number of consecutive timeouts allowed before restarting the head event subscription",
-		Value:   3,
+		Value:   5,
 		EnvVars: []string{"BEACON_EVENT_RESTART"},
 	},
 	&cli.DurationFlag{


### PR DESCRIPTION
# What 🕵️‍♀️
Increases the config `beacon-event-restart` from 3 to 5.

# Why 🔑
Reduces the number of warnings in the relay, allowing up to 5 consecutive missed slots on the network, before resetting the connection
