### PR TITLE
add ttl param for storeManager TTL

### DIFF
--- a/cmd/dreamboat/main.go
+++ b/cmd/dreamboat/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -171,10 +170,16 @@ var flags = []cli.Flag{
 		EnvVars: []string{"RELAY_REGISTRATIONS_CACHE_SIZE"},
 	},
 	&cli.DurationFlag{
-		Name:    "relay-registrations-cache-ttl",
-		Usage:   "registrations cache ttl",
-		Value:   time.Hour,
+		Name:    "relay-registrations-cache-write-ttl",
+		Usage:   "registrations cache ttl for writing",
+		Value:   12 * time.Hour,
 		EnvVars: []string{"RELAY_REGISTRATIONS_CACHE_TTL"},
+	},
+	&cli.DurationFlag{
+		Name:    "relay-registrations-cache-read-ttl",
+		Usage:   "registrations cache ttl for reading",
+		Value:   time.Hour,
+		EnvVars: []string{"RELAY_REGISTRATIONS_CACHE_READ_TTL"},
 	},
 	&cli.BoolFlag{
 		Name:    "relay-publish-block",
@@ -459,7 +464,7 @@ func run() cli.ActionFunc {
 		// lazyload validators cache, it's optional and we don't care if it errors out
 		go preloadValidators(c.Context, logger, valDS, validatorCache)
 
-		validatorStoreManager := validators.NewStoreManager(logger, validatorCache, valDS, int(math.Floor(TTL.Seconds()/2)), c.Uint("relay-store-queue-size"))
+		validatorStoreManager := validators.NewStoreManager(logger, validatorCache, valDS, c.Duration("relay-registrations-cache-write-ttl"), c.Uint("relay-store-queue-size"))
 		validatorStoreManager.AttachMetrics(m)
 		if c.Uint("relay-workers-store-validator") > 0 {
 			validatorStoreManager.RunStore(c.Uint("relay-workers-store-validator"))
@@ -546,7 +551,7 @@ func run() cli.ActionFunc {
 				structs.ForkCapella:   capellaBeaconProposer},
 			PubKey:                pk,
 			SecretKey:             sk,
-			RegistrationCacheTTL:  c.Duration("relay-registrations-cache-ttl"),
+			RegistrationCacheTTL:  c.Duration("relay-registrations-cache-read-ttl"),
 			TTL:                   TTL,
 			AllowedListedBuilders: allowed,
 			PublishBlock:          c.Bool("relay-publish-block"),

--- a/cmd/dreamboat/main.go
+++ b/cmd/dreamboat/main.go
@@ -170,16 +170,16 @@ var flags = []cli.Flag{
 		EnvVars: []string{"RELAY_REGISTRATIONS_CACHE_SIZE"},
 	},
 	&cli.DurationFlag{
-		Name:    "relay-registrations-cache-write-ttl",
-		Usage:   "registrations cache ttl for writing",
-		Value:   12 * time.Hour,
-		EnvVars: []string{"RELAY_REGISTRATIONS_CACHE_TTL"},
-	},
-	&cli.DurationFlag{
 		Name:    "relay-registrations-cache-read-ttl",
 		Usage:   "registrations cache ttl for reading",
 		Value:   time.Hour,
 		EnvVars: []string{"RELAY_REGISTRATIONS_CACHE_READ_TTL"},
+	},
+	&cli.DurationFlag{
+		Name:    "relay-registrations-cache-write-ttl",
+		Usage:   "registrations cache ttl for writing",
+		Value:   12 * time.Hour,
+		EnvVars: []string{"RELAY_REGISTRATIONS_CACHE_WRITE_TTL"},
 	},
 	&cli.BoolFlag{
 		Name:    "relay-publish-block",

--- a/relay/submit.go
+++ b/relay/submit.go
@@ -202,7 +202,9 @@ func (rs *Relay) checkRegistration(ctx context.Context, pubkey types.PublicKey, 
 	if v, ok := rs.cache.Get(pubkey); ok {
 		if int(time.Since(v.Time)) > rand.Intn(int(rs.config.RegistrationCacheTTL))+int(rs.config.RegistrationCacheTTL) {
 			rs.cache.Remove(pubkey)
-		} else if v.Entry.Message.FeeRecipient == proposerFeeRecipient {
+		}
+
+		if v.Entry.Message.FeeRecipient == proposerFeeRecipient {
 			return v.Entry.Message.GasLimit, nil
 		}
 	}

--- a/relay/submit.go
+++ b/relay/submit.go
@@ -12,8 +12,8 @@ import (
 	"github.com/lthibault/log"
 
 	"github.com/blocknative/dreamboat/beacon"
-	wh "github.com/blocknative/dreamboat/datastore/warehouse"
 	rpctypes "github.com/blocknative/dreamboat/client/sim/types"
+	wh "github.com/blocknative/dreamboat/datastore/warehouse"
 	"github.com/blocknative/dreamboat/structs"
 	"github.com/blocknative/dreamboat/structs/forks/bellatrix"
 	"github.com/blocknative/dreamboat/structs/forks/capella"
@@ -202,9 +202,7 @@ func (rs *Relay) checkRegistration(ctx context.Context, pubkey types.PublicKey, 
 	if v, ok := rs.cache.Get(pubkey); ok {
 		if int(time.Since(v.Time)) > rand.Intn(int(rs.config.RegistrationCacheTTL))+int(rs.config.RegistrationCacheTTL) {
 			rs.cache.Remove(pubkey)
-		}
-
-		if v.Entry.Message.FeeRecipient == proposerFeeRecipient {
+		} else if v.Entry.Message.FeeRecipient == proposerFeeRecipient {
 			return v.Entry.Message.GasLimit, nil
 		}
 	}

--- a/validators/storemanager.go
+++ b/validators/storemanager.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"context"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,7 +34,7 @@ type StoreReq struct {
 
 type StoreManager struct {
 	RegistrationCache ValidatorCache
-	writeTTL          time.Duration
+	writeTTLSeconds   int
 
 	store ValidatorStore
 
@@ -51,7 +52,7 @@ func NewStoreManager(l log.Logger, cache ValidatorCache, store ValidatorStore, w
 	rm := &StoreManager{
 		l:                 l,
 		store:             store,
-		writeTTL:          writeTTL,
+		writeTTLSeconds:   int(writeTTL.Seconds()),
 		RegistrationCache: cache,
 		StoreCh:           make(chan StoreReq, storeSize),
 	}
@@ -82,7 +83,7 @@ func (rm *StoreManager) Check(rvg *types.RegisterValidatorRequestMessage) bool {
 		return false
 	}
 
-	if time.Since(v.Time).Seconds() > (rm.writeTTL.Seconds() - (rm.writeTTL.Seconds() * 5 / 100)) {
+	if time.Since(v.Time).Seconds() > float64(rm.writeTTLSeconds+rand.Intn(rm.writeTTLSeconds)-(rm.writeTTLSeconds*5/100)) {
 		return false
 	}
 


### PR DESCRIPTION
# What 🕵️‍♀️
Add a new param for setting the TTL param for storing registrations

# Why 🔑
This is needed so that it is independent from the storage TTL
