### PR TITLE
Delete 'stored in warehouse' logs

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -513,7 +513,6 @@ func (rs *Relay) storeGetPayloadRequest(logger log.Logger, m *structs.MetricGrou
 	}
 
 	m.AppendSince(tStoreWarehouse, "getPayload", "storeWarehouse")
-	logger.Debug("stored in warehouse")
 }
 
 func validatePayload(expected structs.BlockBidAndTrace, requested structs.SignedBlindedBeaconBlock) error {

--- a/relay/submit.go
+++ b/relay/submit.go
@@ -113,7 +113,6 @@ func (rs *Relay) SubmitBlock(ctx context.Context, m *structs.MetricGroup, uc str
 			// we should not return error because it's already been stored for delivery
 		} else {
 			m.AppendSince(tStoreWarehouse, "submitBlock", "storeWarehouse")
-			logger.Debug("stored in warehouse")
 		}
 	}
 


### PR DESCRIPTION
# What 🕵️‍♀️
Delete 'stored in warehouse' logs

# Why 🔑
It does not provide any insight. Instead, we only log when something fails in warehouse
