### PR TITLE
delete print from beacon client payload attr

### DIFF
--- a/beacon/client/client.go
+++ b/beacon/client/client.go
@@ -327,7 +327,6 @@ func (b *beaconClient) SubscribeToPayloadAttributesEvents(payloadAttributesC cha
 			if err != nil {
 				log.WithError(err).Error("could not unmarshal payload_attributes event")
 			} else {
-				fmt.Printf("%v\n", data)
 				payloadAttributesC <- data
 			}
 		})


### PR DESCRIPTION
# What 🕵️‍♀️
Delete print statement from beacon client payload attrs
