### PR TITLE
Make beacon publish block failure 'debug'

### DIFF
--- a/beacon/client/multi.go
+++ b/beacon/client/multi.go
@@ -276,7 +276,7 @@ func publishAsync(ctx context.Context, client BeaconNode, l log.Logger, block st
 	if err != nil {
 		l.WithError(err).
 			WithField("endpoint", client.Endpoint()).
-			Warn("failed to publish block to beacon")
+			Debug("failed to publish block to beacon")
 	}
 	resp <- err
 }


### PR DESCRIPTION
# What 🕵️‍♀️
Change log level from `warn` to `debug`, when beacon `publishBlock` call fails

# Why 🔑
Currently the call is used for validating GetPayload calls, so it is expected to fail from time to time.
