### PR TITLE
Allow getPayload retries for the same blockHash

### DIFF
--- a/relay/metrics.go
+++ b/relay/metrics.go
@@ -7,6 +7,7 @@ import (
 
 type RelayMetrics struct {
 	MissHeaderCount *prometheus.CounterVec
+	RetryCount      *prometheus.CounterVec
 }
 
 func (r *Relay) initMetrics() {
@@ -16,8 +17,16 @@ func (r *Relay) initMetrics() {
 		Name:      "missHeader",
 		Help:      "Number of missed headers by reason (oldSlot, noSubmission)",
 	}, []string{"reason"})
+
+	r.m.RetryCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "dreamboat",
+		Subsystem: "relayprocess",
+		Name:      "retry",
+		Help:      "Number of retries/duplicate requests by endpoint (getPayload, getHeader)",
+	}, []string{"endpoint"})
 }
 
 func (r *Relay) AttachMetrics(m *metrics.Metrics) {
 	m.Register(r.m.MissHeaderCount)
+	m.Register(r.m.RetryCount)
 }

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -452,7 +452,7 @@ func (rs *Relay) GetPayload(ctx context.Context, m *structs.MetricGroup, uc stru
 	storeTrace = true // everything was correct, so flag to store the trace
 
 	if lastDelivery := rs.lastDelivered.Load().(lastDelivered); lastDelivery.slot < payloadRequest.Slot() {
-		rs.lastDelivered.Store(payloadRequest.Slot())
+		rs.lastDelivered.Store(lastDelivered{slot:payloadRequest.Slot(), blockHash: payloadRequest.BlockHash()})
 	} else if lastDelivery.slot == payloadRequest.Slot() && lastDelivery.blockHash != payloadRequest.BlockHash() {
 		return nil, ErrPayloadDiffBlockHash
 	} else if lastDelivery.slot > payloadRequest.Slot() {


### PR DESCRIPTION
# What 🕵️‍♀️
This PR allows multiple `getPayload` requests for the same slot in order to address the issue of reduced chances of successful submission by distributed validators (DVT) when the first submitter's beacon node has connectivity issues. Currently, only one call of `getPayload` is allowed for the same slot, which limits the network outreach of the proposal to only one beacon node. By enabling multiple `getPayload` requests, each participant's Beacon node can independently POST `/eth/v1/builder/blinded_blocks` for the same slot, increasing the chances of successful submission by distributed validators.

# Why 🔑
The limitation of only allowing one `getPayload` call for the same slot negatively impacts the network outreach and reliability of the proposal submission process for distributed validators. By allowing multiple `getPayload` requests, the solution aims to address connectivity issues and improve the overall success rate of submission by distributed validators.

# How ⚙️
In the relay/relay.go file, the changes involve modifying the GetPayload function to address the issue of only allowing one getPayload call for the same slot. The modifications include the following steps:

A new struct, `lastDelivered`, is introduced to track the last delivered slot and its corresponding block hash.
Inside the GetPayload function, the current implementation checks if the requested payload's slot is greater than the last delivered slot. The last delivered slot is updated to the requested slot if it is. However, with the changes, additional conditions are added to handle cases where the requested slot is the same but with a different block hash (`ErrPayloadDiffBlockHash`) or when the requested slot is lower than the last delivered slot (`ErrHigherSlotDelivered`).
If any additional conditions are met, the corresponding error is returned, indicating the failure to retrieve the payload for the given slot. The `RetryCount` metric is also incremented to track the number of retries or duplicate requests for the getPayload endpoint.
Lastly, a new `lastDelivered` struct is stored using the `lastDelivered` `atomic.Value` to update the last delivered slot and block hash.

These modifications allow multiple getPayload requests for the same slot to be handled correctly, preventing the rejection of payloads with different block hashes and handling cases where a higher slot has already been delivered.