### PR TITLE
SSZ / Gzip submissions

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -379,7 +379,7 @@ func (a *API) submitBlock(w http.ResponseWriter, r *http.Request) {
 			if err := creq.UnmarshalSSZ(b); err != nil {
 				// Fallback to JSON.
 				if jsonErr := json.NewDecoder(bytes.NewReader(b)).Decode(&creq); jsonErr != nil {
-					l.Warnf("failed to decode ssz: %w", err)
+					l.Debugf("failed to decode ssz: %w", err)
 					a.m.ApiReqCounter.WithLabelValues("submitBlock", "400", "payload decode ssz").Inc()
 					writeError(w, http.StatusBadRequest, errors.New("invalid submitblock request capella decode ssz"))
 					return

--- a/api/api.go
+++ b/api/api.go
@@ -4,10 +4,12 @@ package api
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -340,13 +342,29 @@ func (a *API) submitBlock(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	uc := structs.UserContent{IP: r.Header.Get("X-Forwarded-For")}
-	var l = a.l.With(log.F{"ip": uc.IP})
+	isGzip := r.Header.Get("Content-Encoding") == "gzip"
+	var l = a.l.With(log.F{"ip": uc.IP, "gzip": isGzip})
 
 	timer := prometheus.NewTimer(a.m.ApiReqTiming.WithLabelValues("submitBlock"))
 	defer timer.ObserveDuration()
-	var req structs.SubmitBlockRequest
 
-	b, err := ioutil.ReadAll(r.Body)
+	var (
+		req    structs.SubmitBlockRequest
+		reader io.Reader = r.Body
+		err    error
+	)
+
+	if isGzip {
+		reader, err = gzip.NewReader(r.Body)
+		if err != nil {
+			a.m.ApiReqCounter.WithLabelValues("submitBlock", "400", "gzip reader").Inc()
+			writeError(w, http.StatusBadRequest, errors.New("invalid gzipped submitblock request decode"))
+			return
+		}
+	}
+
+	reader = io.LimitReader(reader, 10*1024*1024) // 10 MB
+	b, err := ioutil.ReadAll(reader)
 	if err != nil {
 		a.m.ApiReqCounter.WithLabelValues("getPayload", "400", "read body").Inc()
 		writeError(w, http.StatusBadRequest, errors.New("unable to read request body"))
@@ -356,11 +374,22 @@ func (a *API) submitBlock(w http.ResponseWriter, r *http.Request) {
 	switch a.st.ForkVersion(a.st.HeadSlot()) {
 	case structs.ForkCapella:
 		var creq capella.SubmitBlockRequest
-		if err := json.NewDecoder(bytes.NewReader(b)).Decode(&creq); err != nil {
-			a.m.ApiReqCounter.WithLabelValues("submitBlock", "400", "payload decode").Inc()
-			writeError(w, http.StatusBadRequest, errors.New("invalid submitblock request capella decode"))
-			return
+		if r.Header.Get("Content-Type") == "application/octet-stream" {
+			l = l.WithField("requestContentType", "ssz")
+			if err := creq.UnmarshalSSZ(b); err != nil {
+				a.m.ApiReqCounter.WithLabelValues("submitBlock", "400", "payload decode ssz").Inc()
+				writeError(w, http.StatusBadRequest, errors.New("invalid submitblock request capella decode ssz"))
+				return
+			}
+		} else {
+			l = l.WithField("requestContentType", "json")
+			if err := json.NewDecoder(bytes.NewReader(b)).Decode(&creq); err != nil {
+				a.m.ApiReqCounter.WithLabelValues("submitBlock", "400", "payload decode").Inc()
+				writeError(w, http.StatusBadRequest, errors.New("invalid submitblock request capella decode"))
+				return
+			}
 		}
+
 		creq.CapellaRaw = b
 		req = &creq
 		l = l.With(log.F{
@@ -380,6 +409,7 @@ func (a *API) submitBlock(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case structs.ForkBellatrix:
+		l = l.WithField("requestContentType", "json")
 		var breq bellatrix.SubmitBlockRequest
 		if err := json.NewDecoder(bytes.NewReader(b)).Decode(&breq); err != nil {
 			a.m.ApiReqCounter.WithLabelValues("submitBlock", "400", "payload decode").Inc()
@@ -388,7 +418,7 @@ func (a *API) submitBlock(w http.ResponseWriter, r *http.Request) {
 		}
 		breq.BellatrixRaw = b
 		req = &breq
-		l = a.l.With(log.F{
+		l = l.With(log.F{
 			"fork":      "bellatrix",
 			"slot":      breq.BellatrixMessage.Slot,
 			"blockHash": breq.BellatrixMessage.BlockHash,

--- a/relay/metrics.go
+++ b/relay/metrics.go
@@ -7,6 +7,7 @@ import (
 
 type RelayMetrics struct {
 	MissHeaderCount *prometheus.CounterVec
+	RetryCount      *prometheus.CounterVec
 }
 
 func (r *Relay) initMetrics() {
@@ -16,8 +17,16 @@ func (r *Relay) initMetrics() {
 		Name:      "missHeader",
 		Help:      "Number of missed headers by reason (oldSlot, noSubmission)",
 	}, []string{"reason"})
+
+	r.m.RetryCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "dreamboat",
+		Subsystem: "relayprocess",
+		Name:      "retry",
+		Help:      "Number of retries/duplicate requests by endpoint (getPayload, getHeader)",
+	}, []string{"endpoint"})
 }
 
 func (r *Relay) AttachMetrics(m *metrics.Metrics) {
 	m.Register(r.m.MissHeaderCount)
+	m.Register(r.m.RetryCount)
 }

--- a/structs/forks/capella/capella.go
+++ b/structs/forks/capella/capella.go
@@ -31,6 +31,54 @@ func (b *SubmitBlockRequest) Raw() []byte {
 	return b.CapellaRaw
 }
 
+// UnmarshalSSZ ssz unmarshals the SubmitBlockRequest object
+func (s *SubmitBlockRequest) UnmarshalSSZ(buf []byte) error {
+	var err error
+	size := uint64(len(buf))
+	if size < 336 {
+		return ssz.ErrSize
+	}
+
+	tail := buf
+	var o1 uint64
+
+	if err = s.CapellaMessage.UnmarshalSSZ(buf[0:236]); err != nil {
+		return err
+	}
+
+	// Offset (1) 'ExecutionPayload'
+	if o1 = ssz.ReadOffset(buf[236:240]); o1 > size {
+		return ssz.ErrOffset
+	}
+
+	if o1 < 336 {
+		return ssz.ErrInvalidVariableOffset
+	}
+
+	// Field (2) 'Signature'
+	copy(s.CapellaSignature[:], buf[240:336])
+
+	// Field (1) 'ExecutionPayload'
+	{
+		buf = tail[o1:]
+		if err = s.CapellaExecutionPayload.UnmarshalSSZ(buf); err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// SizeSSZ returns the ssz encoded size in bytes for the SubmitBlockRequest object
+func (s *SubmitBlockRequest) SizeSSZ() (size int) {
+	size = 336
+
+	// Field (1) 'ExecutionPayload'
+	size += s.CapellaExecutionPayload.SizeSSZ()
+
+	return
+}
+
+
 func (b *SubmitBlockRequest) TraceBlockHash() types.Hash {
 	return b.CapellaMessage.BlockHash
 }
@@ -274,6 +322,147 @@ type ExecutionPayload struct {
 	bellatrix.ExecutionPayload
 	EpWithdrawals structs.Withdrawals `json:"withdrawals" ssz-max:"16"`
 }
+
+// UnmarshalSSZ ssz unmarshals the ExecutionPayload object
+func (e *ExecutionPayload) UnmarshalSSZ(buf []byte) error {
+	var err error
+	size := uint64(len(buf))
+	if size < 512 {
+		return ssz.ErrSize
+	}
+
+	tail := buf
+	var o10, o13, o14 uint64
+
+	// Field (0) 'ParentHash'
+	copy(e.EpParentHash[:], buf[0:32])
+
+	// Field (1) 'FeeRecipient'
+	copy(e.EpFeeRecipient[:], buf[32:52])
+
+	// Field (2) 'StateRoot'
+	copy(e.EpStateRoot[:], buf[52:84])
+
+	// Field (3) 'ReceiptsRoot'
+	copy(e.EpReceiptsRoot[:], buf[84:116])
+
+	// Field (4) 'LogsBloom'
+	copy(e.EpLogsBloom[:], buf[116:372])
+
+	// Field (5) 'PrevRandao'
+	copy(e.EpRandom[:], buf[372:404])
+
+	// Field (6) 'BlockNumber'
+	e.EpBlockNumber = ssz.UnmarshallUint64(buf[404:412])
+
+	// Field (7) 'GasLimit'
+	e.EpGasLimit = ssz.UnmarshallUint64(buf[412:420])
+
+	// Field (8) 'GasUsed'
+	e.EpGasUsed = ssz.UnmarshallUint64(buf[420:428])
+
+	// Field (9) 'Timestamp'
+	e.EpTimestamp = ssz.UnmarshallUint64(buf[428:436])
+
+	// Offset (10) 'ExtraData'
+	if o10 = ssz.ReadOffset(buf[436:440]); o10 > size {
+		return ssz.ErrOffset
+	}
+
+	if o10 < 512 {
+		return ssz.ErrInvalidVariableOffset
+	}
+
+	// Field (11) 'BaseFeePerGas'
+	copy(e.EpBaseFeePerGas[:], buf[440:472])
+
+	// Field (12) 'BlockHash'
+	copy(e.EpBlockHash[:], buf[472:504])
+
+	// Offset (13) 'Transactions'
+	if o13 = ssz.ReadOffset(buf[504:508]); o13 > size || o10 > o13 {
+		return ssz.ErrOffset
+	}
+
+	// Offset (14) 'Withdrawals'
+	if o14 = ssz.ReadOffset(buf[508:512]); o14 > size || o13 > o14 {
+		return ssz.ErrOffset
+	}
+
+	// Field (10) 'ExtraData'
+	{
+		buf = tail[o10:o13]
+		if len(buf) > 32 {
+			return ssz.ErrBytesLength
+		}
+		if cap(e.EpExtraData) == 0 {
+			e.EpExtraData = make([]byte, 0, len(buf))
+		}
+		e.EpExtraData = append(e.EpExtraData, buf...)
+	}
+
+	// Field (13) 'Transactions'
+	{
+		buf = tail[o13:o14]
+		num, err := ssz.DecodeDynamicLength(buf, 1048576)
+		if err != nil {
+			return err
+		}
+		e.EpTransactions = make([]hexutil.Bytes, num)
+		err = ssz.UnmarshalDynamic(buf, num, func(indx int, buf []byte) (err error) {
+			if len(buf) > 1073741824 {
+				return ssz.ErrBytesLength
+			}
+			if cap(e.EpTransactions[indx]) == 0 {
+				e.EpTransactions[indx] = make([]byte, 0, len(buf))
+			}
+			e.EpTransactions[indx] = append(e.EpTransactions[indx], buf...)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Field (14) 'Withdrawals'
+	{
+		buf = tail[o14:]
+		num, err := ssz.DivideInt2(len(buf), 44, 16)
+		if err != nil {
+			return err
+		}
+		e.EpWithdrawals = make(structs.Withdrawals, num)
+		for ii := 0; ii < num; ii++ {
+			if e.EpWithdrawals[ii] == nil {
+				e.EpWithdrawals[ii] = new(structs.Withdrawal)
+			}
+			if err = e.EpWithdrawals[ii].UnmarshalSSZ(buf[ii*44 : (ii+1)*44]); err != nil {
+				return err
+			}
+		}
+	}
+	return err
+}
+
+// SizeSSZ returns the ssz encoded size in bytes for the ExecutionPayload object
+func (e *ExecutionPayload) SizeSSZ() (size int) {
+	size = 512
+
+	// Field (10) 'ExtraData'
+	size += len(e.EpExtraData)
+
+	// Field (13) 'Transactions'
+	for ii := 0; ii < len(e.EpTransactions); ii++ {
+		size += 4
+		size += len(e.EpTransactions[ii])
+	}
+
+	// Field (14) 'Withdrawals'
+	size += len(e.EpWithdrawals) * 44
+
+	return
+}
+
 
 // GetHeaderResponse is the response payload from the getHeader request: https://github.com/ethereum/builder-specs/pull/2/files#diff-c80f52e38c99b1049252a99215450a29fd248d709ffd834a9480c98a233bf32c
 type GetHeaderResponse struct {

--- a/structs/withdrawals.go
+++ b/structs/withdrawals.go
@@ -65,6 +65,35 @@ type Withdrawal struct {
 	Amount         uint64        `json:"amount,string"`
 }
 
+// UnmarshalSSZ ssz unmarshals the Withdrawal object
+func (w *Withdrawal) UnmarshalSSZ(buf []byte) error {
+	var err error
+	size := uint64(len(buf))
+	if size != 44 {
+		return ssz.ErrSize
+	}
+
+	// Field (0) 'Index'
+	w.Index = uint64(ssz.UnmarshallUint64(buf[0:8]))
+
+	// Field (1) 'ValidatorIndex'
+	w.ValidatorIndex = uint64(ssz.UnmarshallUint64(buf[8:16]))
+
+	// Field (2) 'Address'
+	copy(w.Address[:], buf[16:36])
+
+	// Field (3) 'Amount'
+	w.Amount = uint64(ssz.UnmarshallUint64(buf[36:44]))
+
+	return err
+}
+
+// SizeSSZ returns the ssz encoded size in bytes for the Withdrawal object
+func (w *Withdrawal) SizeSSZ() (size int) {
+	size = 44
+	return
+}
+
 // HashTreeRoot ssz hashes the Withdrawal object
 func (w *Withdrawal) HashTreeRoot() ([32]byte, error) {
 	return ssz.HashWithDefaultHasher(w)


### PR DESCRIPTION
## What 🕵️‍♀️
This pull request introduces changes to enhance the codebase and improve the handling of SSZ (Simple Serialize) data and gzip compression. These changes are motivated by the discussions and requirements outlined in [PR #388](https://github.com/flashbots/mev-boost-relay/pull/388/).

## Why 🔑
The need for these changes arises from the requirement to support different content types and improve the overall efficiency and flexibility of the system.

## How ⚙️
The following components were modified or added to achieve the desired enhancements:

1. **SSZ Decoding**:
   - Added support for decoding SSZ-encoded data in the `submitBlock` endpoint.
   - If the request has a content type of `application/octet-stream`, the payload is unmarshaled using the SSZ format.
   - In case of a decoding error, a fallback to JSON decoding is implemented.
   - The SSZ decoding logic is implemented in the `capella.SubmitBlockRequest` struct's `UnmarshalSSZ` method.

2. **Gzip Compression**:
   - Enabled support for gzip compression in the request body of the `submitBlock` endpoint.
   - If the request includes the `Content-Encoding` header with the value "gzip," the request body is read using a gzip reader.
   - The maximum limit for the request body size is increased to 10 MB.
   - The gzip decompression is performed using the `compress/gzip` package.

These modifications enable the system to handle SSZ-encoded payloads and gzip-compressed request bodies, providing better interoperability and efficiency in data transmission.
