### PR TITLE
Fix Relay Data API Responses for Empty Results

### DIFF
--- a/datastore/evidence/postgres/blocks.go
+++ b/datastore/evidence/postgres/blocks.go
@@ -115,10 +115,10 @@ func (s *Datastore) GetBuilderBlockSubmissions(ctx context.Context, w io.Writer,
 		if err != nil {
 			s.m.ErrorsCount.WithLabelValues("getBuilderBlockSubmissions", "scan").Inc()
 			s.l.WithError(err).Warn("failed to scan row")
-			fmt.Fprint(w, "]")
 			if idx == 0 {
 				return err
 			}
+			fmt.Fprint(w, "]")
 			return nil
 		}
 		bt.BuilderPubkey.UnmarshalText(builderpubkey)
@@ -161,8 +161,12 @@ func (s *Datastore) GetBuilderBlockSubmissions(ctx context.Context, w io.Writer,
 		}
 	}
 
-	fmt.Fprint(w, "]") // Write the closing bracket manually
-	return nil
+	if idx == 0 {
+		_, err := fmt.Fprint(w, "[]")
+		return err
+	}
+	_, err = fmt.Fprint(w, "]")
+	return err
 }
 
 type GetBuilderSubmissionsFilters struct {

--- a/datastore/evidence/postgres/payload.go
+++ b/datastore/evidence/postgres/payload.go
@@ -131,10 +131,10 @@ func (s *Datastore) GetDeliveredPayloads(ctx context.Context, w io.Writer, headS
 		if err != nil {
 			s.m.ErrorsCount.WithLabelValues("getDeliveredPayloads", "scan").Inc()
 			s.l.WithError(err).Warn("failed to scan row")
-			fmt.Fprint(w, "]")
 			if idx == 0 {
 				return err
 			}
+			fmt.Fprint(w, "]")
 			return nil
 		}
 
@@ -174,8 +174,12 @@ func (s *Datastore) GetDeliveredPayloads(ctx context.Context, w io.Writer, headS
 		}
 	}
 
-	fmt.Fprint(w, "]") // Write the closing bracket manually
-	return nil
+	if idx == 0 {
+		_, err := fmt.Fprint(w, "[]")
+		return err
+	}
+	_, err = fmt.Fprint(w, "]")
+	return err
 }
 
 /*


### PR DESCRIPTION
# What 🕵️‍♀️
This PR addresses the issue of incorrect responses on the Relay Data API when the response is empty. It ensures that the response is properly handled and formatted in such cases.

# Why 🔑
The need for this change arises from the requirement to handle empty responses correctly. Previously, when the response was empty, the closing bracket was not written, resulting in malformed JSON. This PR fixes that issue by manually writing the closing bracket and returning an empty array when the response is empty.

# How ⚙️
The following components were modified:

- `datastore/evidence/postgres/blocks.go`: 
  - The `GetBuilderBlockSubmissions` function was updated to handle the case of an empty response. The code was modified to write the closing bracket manually and return an empty array if the response is empty.

- `datastore/evidence/postgres/payload.go`:
  - The `GetDeliveredPayloads` function was modified to handle empty responses. Similar to the previous component, the code was updated to write the closing bracket manually and return an empty array when the response is empty.

These changes ensure that the responses from the Relay Data API are correctly formatted, even when there are no results to return. 

# Testing 🧪
- [x] Run `go test -race ./...` from the root directory to perform testing.
