### PR TITLE
Feat/refactor streaming ww prep

### DIFF
--- a/cmd/dreamboat/config/config.go
+++ b/cmd/dreamboat/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Config struct {
@@ -300,7 +302,7 @@ var DefaultWarehouseConfig = &WarehouseConfig{
 type DistributedConfig struct {
 	Redis *RedisStreamConfig `config:"redis"`
 
-	InstanceID string `config:"id"`
+	InstanceID uuid.UUID `config:"id"`
 
 	// Number of workers for storing data in warehouse, if 0, then data is not exported
 	WorkerNumber int `config:"workers"`
@@ -310,6 +312,17 @@ type DistributedConfig struct {
 
 	// stream entire block for every bid that is served in GetHeader requests.
 	StreamServedBids bool `config:"stream_served_bids"`
+}
+
+// LocalNode returns a unique identifier for the locally-running relay.  If the
+// InstanceID field is set, LocalNode() returns its value.  Else, a random UUID
+// is generated and assigned to InstanceID before LocalNode() returns.
+func (c *DistributedConfig) LocalNode() uuid.UUID {
+	if c.InstanceID == uuid.Nil {
+		c.InstanceID = uuid.Must(uuid.NewRandom())
+	}
+
+	return c.InstanceID
 }
 
 var DefaultDistributedConfig = &DistributedConfig{

--- a/cmd/dreamboat/main.go
+++ b/cmd/dreamboat/main.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"fmt"
 	"math/rand"
 	"net/http"
 	"os"
 	"os/signal"
+	"path"
 	"syscall"
 
 	"time"
@@ -27,7 +27,6 @@ import (
 	"github.com/blocknative/dreamboat/sim"
 	"github.com/blocknative/dreamboat/sim/client/fallback"
 	"github.com/blocknative/dreamboat/stream"
-	"github.com/google/uuid"
 	badger "github.com/ipfs/go-ds-badger2"
 
 	fileS "github.com/blocknative/dreamboat/cmd/dreamboat/config/source/file"
@@ -123,7 +122,7 @@ func main() {
 	var (
 		storage  datastore.TTLStorage
 		badgerDs *badger.Datastore
-		streamer relay.Streamer
+		streamer *stream.Client
 		err      error
 	)
 
@@ -143,24 +142,25 @@ func main() {
 		readClient := redis.NewClient(&redis.Options{
 			Addr: cfg.Payload.Redis.Read.Address,
 		})
+		defer readClient.Close()
 		m.RegisterRedis("redis", "readreplica", readClient)
 
 		writeClient := redis.NewClient(&redis.Options{
 			Addr: cfg.Payload.Redis.Write.Address,
 		})
+		defer writeClient.Close()
 		m.RegisterRedis("redis", "master", writeClient)
 		storage = &dsRedis.RedisDatastore{Read: readClient, Write: writeClient}
 
 		redisClient := redis.NewClient(&redis.Options{
 			Addr: cfg.Distributed.Redis.Address,
 		})
-
+		defer redisClient.Close()
 		m.RegisterRedis("redis", "stream", redisClient)
-		streamer, err = initStreamer(ctx, cfg.Distributed, redisClient, logger, m, state)
-		if err != nil {
-			logger.WithError(err).Error("fail to create streamer")
-			return
-		}
+
+		streamer = newStreamClient(cfg.Distributed, redisClient, logger, m, state)
+		defer streamer.Close()
+
 	} else {
 		storage = badgerDs
 	}
@@ -519,34 +519,52 @@ func ComputeDomain(domainType types.DomainType, forkVersionHex string, genesisVa
 	return types.ComputeDomain(domainType, forkVersion, genesisValidatorsRoot), nil
 }
 
-func initStreamer(ctx context.Context, cfg *config.DistributedConfig, redisClient *redis.Client, l log.Logger, m *metrics.Metrics, st stream.State) (relay.Streamer, error) {
-	timeStreamStart := time.Now()
+func newStreamClient(cfg *config.DistributedConfig, redisClient *redis.Client, l log.Logger, m *metrics.Metrics, st stream.State) *stream.Client {
+	//// TODO:  move this to where the stream subscribers are actually started
+	// timeStreamStart := time.Now()
+	// defer func() {
+	// 	l.WithField("relay-service", "stream-subscriber").
+	// 		WithField("startTimeMs", time.Since(timeStreamStart).Milliseconds()).
+	// 		Info("initialized")
+	// }()
 
-	pubsub := &redisStream.Pubsub{Redis: redisClient, Logger: l}
-
-	id := cfg.InstanceID
-	if id == "" {
-		id = uuid.NewString()
+	return &stream.Client{
+		State: st,
+		Logger: l.
+			WithField("subService", "stream").
+			WithField("type", "redis"),
+		Bids: &redisStream.Topic{
+			Redis:     redisClient,
+			Logger:    l.WithField("topic", stream.BidTopic),
+			Name:      path.Join(cfg.Redis.Topic, stream.BidTopic),
+			LocalNode: cfg.LocalNode(),
+		},
+		Cache: &redisStream.Topic{
+			Redis:     redisClient,
+			Logger:    l.WithField("topic", stream.CacheTopic),
+			Name:      path.Join(cfg.Redis.Topic, stream.CacheTopic),
+			LocalNode: cfg.LocalNode(),
+		},
+		QueueSize:  cfg.StreamQueueSize,
+		NumWorkers: cfg.WorkerNumber,
+		Metrics:    m,
 	}
 
-	streamConfig := stream.StreamConfig{
-		Logger:          l,
-		ID:              id,
-		PubsubTopic:     cfg.Redis.Topic,
-		StreamQueueSize: cfg.StreamQueueSize,
-	}
+	// // ...
 
-	redisStreamer := stream.NewClient(pubsub, st, streamConfig)
-	redisStreamer.AttachMetrics(m)
+	// streamConfig := stream.StreamConfig{
+	// 	Logger:          l,
+	// 	ID:              id,
+	// 	PubsubTopic:     cfg.Redis.Topic,
+	// 	StreamQueueSize: cfg.StreamQueueSize,
+	// }
 
-	if err := redisStreamer.RunSubscriberParallel(ctx, uint(cfg.WorkerNumber)); err != nil {
-		return nil, fmt.Errorf("fail to start stream subscriber: %w", err)
-	}
+	// redisStreamer := stream.NewClient(pubsub, st, streamConfig)
+	// redisStreamer.AttachMetrics(m)
 
-	l.With(log.F{
-		"relay-service": "stream-subscriber",
-		"startTimeMs":   time.Since(timeStreamStart).Milliseconds(),
-	}).Info("initialized")
+	// if err := redisStreamer.RunSubscriberParallel(ctx, uint(cfg.WorkerNumber)); err != nil {
+	// 	return nil, fmt.Errorf("fail to start stream subscriber: %w", err)
+	// }
 
-	return redisStreamer, nil
+	// return redisStreamer, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
+	github.com/jpillora/backoff v1.0.0
 	github.com/lib/pq v1.10.8
 	github.com/lthibault/log v1.2.3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -843,6 +843,7 @@ github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqx
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/stream/metrics.go
+++ b/stream/metrics.go
@@ -1,14 +1,13 @@
 package stream
 
 import (
-	"github.com/blocknative/dreamboat/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type StreamMetrics struct {
-	RecvCounter *prometheus.CounterVec
-	Timing      *prometheus.HistogramVec
-	PublishSize *prometheus.HistogramVec
+type streamMetrics struct {
+	RecvCounter    *prometheus.CounterVec
+	Timing         *prometheus.HistogramVec
+	PublishSize    *prometheus.HistogramVec
 	PublishCounter *prometheus.CounterVec
 }
 
@@ -40,11 +39,9 @@ func (s *Client) initMetrics() {
 		Name:      "publishCounter",
 		Help:      "Number of publications per function",
 	}, []string{"function"})
-}
 
-func (s *Client) AttachMetrics(m *metrics.Metrics) {
-	m.Register(s.m.RecvCounter)
-	m.Register(s.m.Timing)
-	m.Register(s.m.PublishSize)
-	m.Register(s.m.PublishCounter)
+	s.Metrics.Register(s.m.RecvCounter)
+	s.Metrics.Register(s.m.Timing)
+	s.Metrics.Register(s.m.PublishSize)
+	s.Metrics.Register(s.m.PublishCounter)
 }

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -4,36 +4,30 @@ package stream
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/lthibault/log"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/blocknative/dreamboat/stream/transport"
 	"github.com/blocknative/dreamboat/structs"
 	"github.com/blocknative/dreamboat/structs/forks/bellatrix"
 	"github.com/blocknative/dreamboat/structs/forks/capella"
 )
 
-var (
+const (
 	CacheTopic         = "/block/cache"
 	BidTopic           = "/block/bid"
 	SlotDeliveredTopic = "/slot/delivered"
 )
 
-type Pubsub interface {
-	Publish(context.Context, string, []byte) error
-	Subscribe(context.Context, string) chan []byte
-}
-
-type StreamConfig struct {
-	Logger          log.Logger
-	ID              string
-	PubsubTopic     string // pubsub topic name for block submissions
-	StreamQueueSize int
+type PubSub interface {
+	Publish(context.Context, transport.Message) error
+	Subscribe(context.Context) transport.Subscription
 }
 
 type State interface {
@@ -41,192 +35,199 @@ type State interface {
 	HeadSlot() structs.Slot
 }
 
+type Metrics interface {
+	Register(prometheus.Collector) error
+}
+
 type Client struct {
-	Pubsub Pubsub
+	once sync.Once
 
-	builderBidIn     chan []byte
-	builderBidOut    chan structs.BuilderBidExtended
-	cacheIn          chan []byte
-	cacheOut         chan structs.BlockAndTraceExtended
-	slotDeliveredIn  chan []byte
-	slotDeliveredOut chan uint64
+	Logger                log.Logger
+	State                 State
+	Bids, Cache           PubSub
+	QueueSize, NumWorkers int
 
-	Config StreamConfig
-	Logger log.Logger
+	Metrics Metrics
+	m       streamMetrics
 
-	m StreamMetrics
+	ctx    context.Context
+	cancel context.CancelFunc
 
-	//slotDelivered chan structs.Slot
+	builderBidOut chan structs.BuilderBidExtended
+	cacheOut      chan structs.BlockAndTraceExtended
 
 	st State
 }
 
-func NewClient(ps Pubsub, st State, cfg StreamConfig) *Client {
-	s := Client{
-		Pubsub: ps,
-		st:     st,
+func (c *Client) init() {
+	c.once.Do(func() {
+		c.initMetrics()
 
-		builderBidIn:     make(chan []byte, cfg.StreamQueueSize),
-		builderBidOut:    make(chan structs.BuilderBidExtended, cfg.StreamQueueSize),
-		cacheIn:          make(chan []byte, cfg.StreamQueueSize),
-		cacheOut:         make(chan structs.BlockAndTraceExtended, cfg.StreamQueueSize),
-		slotDeliveredIn:  make(chan []byte, cfg.StreamQueueSize),
-		slotDeliveredOut: make(chan uint64, cfg.StreamQueueSize),
+		if c.Logger == nil {
+			c.Logger = log.New()
+		}
 
-		Config: cfg,
-		Logger: cfg.Logger.WithField("subService", "stream").WithField("type", "redis"),
-	}
+		c.builderBidOut = make(chan structs.BuilderBidExtended, c.QueueSize)
+		c.cacheOut = make(chan structs.BlockAndTraceExtended, c.QueueSize)
 
-	s.initMetrics()
-
-	return &s
+		c.ctx, c.cancel = context.WithCancel(context.Background())
+		go c.subscribe(c.Bids, c.handleBid)
+		go c.subscribe(c.Cache, c.handleCache)
+	})
 }
 
-func (s *Client) RunSubscriberParallel(ctx context.Context, num uint) error {
-	s.builderBidIn = s.Pubsub.Subscribe(ctx, s.Config.PubsubTopic+BidTopic)
-	s.cacheIn = s.Pubsub.Subscribe(ctx, s.Config.PubsubTopic+CacheTopic)
-	s.slotDeliveredIn = s.Pubsub.Subscribe(ctx, s.Config.PubsubTopic+SlotDeliveredTopic)
-
-	for i := uint(0); i < num; i++ {
-		go s.RunBlockCacheSubscriber(ctx)
-		go s.RunBuilderBidSubscriber(ctx)
-	}
-
-	go s.RunSlotDeliveredSubscriber(ctx)
-
+func (c *Client) Close() error {
+	c.once.Do(func() {
+		c.ctx, c.cancel = context.WithCancel(context.Background())
+	})
+	c.cancel()
 	return nil
 }
 
 func (s *Client) BlockCache() <-chan structs.BlockAndTraceExtended {
+	s.init()
 	return s.cacheOut
 }
 
-func (s *Client) RunBlockCacheSubscriber(ctx context.Context) error {
-	l := s.Logger.WithField("method", "runCacheSubscriber")
-	var bbt structs.BlockAndTraceExtended
+func (c *Client) handleCache(msg transport.Message) {
+	var (
+		receivedAt = time.Now()
+		bbt        structs.BlockAndTraceExtended
+	)
 
-	for raw := range s.cacheIn {
-		receivedAt := time.Now()
-		sData, err := s.decode(raw)
-		if err != nil {
-			l.WithError(err).Warn("failed to decode cache wrapper")
-			continue
+	switch forkEncoding := msg.ForkEncoding; forkEncoding {
+	case transport.BellatrixJson:
+		var bbbt bellatrix.BlockBidAndTrace
+		if err := json.Unmarshal(msg.Payload, &bbbt); err != nil {
+			c.Logger.WithError(err).
+				WithField("method", "runCacheSubscriber").
+				WithField("forkEncoding", forkEncoding).
+				Warn("failed to decode cache")
+			return
 		}
-
-		if sData.Meta().Source == s.Config.ID {
-			continue
+		bbt = &bbbt
+	case transport.CapellaJson:
+		var cbbt capella.BlockAndTraceExtended
+		if err := json.Unmarshal(msg.Payload, &cbbt); err != nil {
+			c.Logger.WithError(err).
+				WithField("method", "runCacheSubscriber").
+				WithField("forkEncoding", forkEncoding).
+				Warn("failed to decode cache")
+			return
 		}
-
-		switch forkEncoding := sData.Meta().ForkEncoding; forkEncoding {
-		case BellatrixJson:
-			var bbbt bellatrix.BlockBidAndTrace
-			if err := json.Unmarshal(sData.Data(), &bbbt); err != nil {
-				l.WithError(err).WithField("forkEncoding", forkEncoding).Warn("failed to decode cache")
-				continue
-			}
-			bbt = &bbbt
-		case CapellaJson:
-			var cbbt capella.BlockAndTraceExtended
-			if err := json.Unmarshal(sData.Data(), &cbbt); err != nil {
-				l.WithError(err).WithField("forkEncoding", forkEncoding).Warn("failed to decode cache")
-				continue
-			}
-			bbt = &cbbt
-		case CapellaSSZ:
-			var cbbt capella.BlockAndTraceExtended
-			if err := cbbt.UnmarshalSSZ(sData.Data()); err != nil {
-				l.WithError(err).WithField("forkEncoding", forkEncoding).Warn("failed to decode cache")
-				continue
-			}
-			bbt = &cbbt
-		default:
-			l.WithField("forkEncoding", forkEncoding).Warn("unkown cache forkEncoding")
-			continue
+		bbt = &cbbt
+	case transport.CapellaSSZ:
+		var cbbt capella.BlockAndTraceExtended
+		if err := cbbt.UnmarshalSSZ(msg.Payload); err != nil {
+			c.Logger.WithError(err).
+				WithField("method", "runCacheSubscriber").
+				WithField("forkEncoding", forkEncoding).
+				Warn("failed to decode cache")
+			return
 		}
+		bbt = &cbbt
+	default:
+		c.Logger.
+			WithField("method", "runCacheSubscriber").
+			WithField("forkEncoding", forkEncoding).
+			Warn("unkown cache forkEncoding")
+		return
+	}
 
-		l.With(log.F{
+	select {
+	case <-c.ctx.Done():
+	case c.cacheOut <- bbt:
+		c.Logger.With(log.F{
+			"method":    "runCacheSubscriber",
 			"itemType":  "blockCache",
 			"blockHash": bbt.ExecutionPayload().BlockHash(),
 			"timestamp": receivedAt.String(),
 		}).Debug("received")
 
-		s.m.RecvCounter.WithLabelValues("cache").Inc()
-		select {
-		case s.cacheOut <- bbt:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		c.m.RecvCounter.WithLabelValues("cache").Inc()
 	}
-	return ctx.Err()
 }
 
 func (s *Client) BuilderBid() <-chan structs.BuilderBidExtended {
 	return s.builderBidOut
 }
 
-func (s *Client) RunBuilderBidSubscriber(ctx context.Context) error {
-	l := s.Logger.WithField("method", "runBuilderBidSubscriber")
-	var bb structs.BuilderBidExtended
+func (c *Client) subscribe(ps PubSub, handle func(transport.Message)) {
+	s := c.Bids.Subscribe(c.ctx)
+	defer s.Close()
 
-	for raw := range s.builderBidIn {
-		receivedAt := time.Now()
-		sData, err := s.decode(raw)
+	for {
+		msg, err := s.Next(c.ctx)
 		if err != nil {
-			l.WithError(err).Warn("failed to decode builder bid  wrapper")
-			continue
+			return // subscription only returns fatal errors
 		}
 
-		if sData.Meta().Source == s.Config.ID {
-			continue
-		}
+		handle(msg)
+	}
+}
 
-		switch forkEncoding := sData.Meta().ForkEncoding; forkEncoding {
-		case BellatrixJson:
-			var bbb bellatrix.BuilderBidExtended
-			if err := json.Unmarshal(sData.Data(), &bbb); err != nil {
-				l.WithError(err).WithField("forkEncoding", forkEncoding).Warn("failed to decode builder bid")
-				continue
-			}
-			bb = &bbb
-		case CapellaJson:
-			var cbb capella.BuilderBidExtended
-			if err := json.Unmarshal(sData.Data(), &cbb); err != nil {
-				l.WithError(err).WithField("forkEncoding", forkEncoding).Warn("failed to decode builder bid")
-				continue
-			}
-			bb = &cbb
-		case CapellaSSZ:
-			var cbb capella.BuilderBidExtended
-			if err := cbb.UnmarshalSSZ(sData.Data()); err != nil {
-				l.WithError(err).WithField("forkEncoding", forkEncoding).Warn("failed to decode builder bid")
-				continue
-			}
-			bb = &cbb
-		default:
-			l.WithField("forkEncoding", forkEncoding).Warn("unkown builder bid forkEncoding")
-			continue
+func (c *Client) handleBid(msg transport.Message) {
+	var (
+		receivedAt = time.Now()
+		bb         structs.BuilderBidExtended
+	)
+
+	switch forkEncoding := msg.ForkEncoding; forkEncoding {
+	case transport.BellatrixJson:
+		var bbb bellatrix.BuilderBidExtended
+		if err := json.Unmarshal(msg.Payload, &bbb); err != nil {
+			c.Logger.WithError(err).
+				WithField("method", "runBuilderBidSubscriber").
+				WithField("forkEncoding", forkEncoding).
+				Warn("failed to decode builder bid")
+			return
 		}
-		l.With(log.F{
+		bb = &bbb
+	case transport.CapellaJson:
+		var cbb capella.BuilderBidExtended
+		if err := json.Unmarshal(msg.Payload, &cbb); err != nil {
+			c.Logger.WithError(err).
+				WithField("method", "runBuilderBidSubscriber").
+				WithField("forkEncoding", forkEncoding).
+				Warn("failed to decode builder bid")
+			return
+		}
+		bb = &cbb
+	case transport.CapellaSSZ:
+		var cbb capella.BuilderBidExtended
+		if err := cbb.UnmarshalSSZ(msg.Payload); err != nil {
+			c.Logger.WithError(err).
+				WithField("method", "runBuilderBidSubscriber").
+				WithField("forkEncoding", forkEncoding).
+				Warn("failed to decode builder bid")
+			return
+		}
+		bb = &cbb
+	default:
+		c.Logger.
+			WithField("method", "runBuilderBidSubscriber").
+			WithField("forkEncoding", forkEncoding).
+			Warn("unkown builder bid forkEncoding")
+		return
+	}
+
+	select {
+	case <-c.ctx.Done():
+	case c.builderBidOut <- bb:
+		c.Logger.With(log.F{
+			"method":    "runBuilderBidSubscriber",
 			"itemType":  "builderBid",
 			"blockHash": bb.BuilderBid().Header().GetBlockHash(),
 			"timestamp": receivedAt.String(),
 		}).Debug("received")
 
-		s.m.RecvCounter.WithLabelValues("bid").Inc()
-		select {
-		case s.builderBidOut <- bb:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		c.m.RecvCounter.WithLabelValues("bid").Inc()
 	}
-	return ctx.Err()
-}
-
-func (s *Client) RunSlotDeliveredSubscriber(ctx context.Context) error {
-	return nil // TODO
 }
 
 func (s *Client) PublishBuilderBid(ctx context.Context, bid structs.BuilderBidExtended) error {
+	s.init()
+
 	timer0 := prometheus.NewTimer(s.m.Timing.WithLabelValues("publishBuilderBid", "all"))
 
 	timer1 := prometheus.NewTimer(s.m.Timing.WithLabelValues("publishBuilderBid", "encode"))
@@ -239,33 +240,35 @@ func (s *Client) PublishBuilderBid(ctx context.Context, bid structs.BuilderBidEx
 	timer1.ObserveDuration()
 
 	l := s.Logger.With(log.F{
-		"method":    "publishBuilderBid",
-		"itemType":  "builderBid",
-		"size":      len(b),
+		"method":   "publishBuilderBid",
+		"itemType": "builderBid",
+		// "size":      len(b),
 		"blockHash": bid.BuilderBid().Header().GetBlockHash(),
 	})
 
 	timer2 := prometheus.NewTimer(s.m.Timing.WithLabelValues("publishBuilderBid", "publish"))
 	l.WithField("timestamp", time.Now().String()).Debug("publishing")
-	if err := s.Pubsub.Publish(ctx, s.Config.PubsubTopic+BidTopic, b); err != nil {
+	if err := s.Bids.Publish(ctx, b); err != nil {
 		return fmt.Errorf("fail to encode encode and stream block: %w", err)
 	}
 	l.WithField("timestamp", time.Now().String()).Debug("published")
 	timer2.ObserveDuration()
 
-	s.m.PublishSize.WithLabelValues("publishBuilderBid").Observe(float64(len(b)))
-	s.m.PublishCounter.WithLabelValues("publishBuilderBid").Add(float64(len(b)))
+	// s.m.PublishSize.WithLabelValues("publishBuilderBid").Observe(float64(len(b)))
+	// s.m.PublishCounter.WithLabelValues("publishBuilderBid").Add(float64(len(b)))
 
 	timer0.ObserveDuration()
 	return nil
 }
 
 func (s *Client) PublishBlockCache(ctx context.Context, block structs.BlockAndTraceExtended) error {
+	s.init()
+
 	timer0 := prometheus.NewTimer(s.m.Timing.WithLabelValues("publishCacheBlock", "all"))
 
 	timer1 := prometheus.NewTimer(s.m.Timing.WithLabelValues("publishCacheBlock", "encode"))
 	forkEncoding := toBlockCacheFormat(s.st.ForkVersion(structs.Slot(block.Slot())))
-	b, err := s.encode(block, forkEncoding)
+	msg, err := s.encode(block, forkEncoding)
 	if err != nil {
 		timer1.ObserveDuration()
 		return fmt.Errorf("fail to encode cache block: %w", err)
@@ -273,23 +276,23 @@ func (s *Client) PublishBlockCache(ctx context.Context, block structs.BlockAndTr
 	timer1.ObserveDuration()
 
 	l := s.Logger.With(log.F{
-		"method":    "publishBlockCache",
-		"itemType":  "blockCache",
-		"size":      len(b),
+		"method":   "publishBlockCache",
+		"itemType": "blockCache",
+		// "size":      len(b),
 		"blockHash": block.ExecutionPayload().BlockHash(),
 		"timestamp": time.Now().String(),
 	})
 
 	timer2 := prometheus.NewTimer(s.m.Timing.WithLabelValues("publishCacheBlock", "publish"))
 	l.WithField("timestamp", time.Now().String()).Debug("publishing")
-	if err := s.Pubsub.Publish(ctx, s.Config.PubsubTopic+CacheTopic, b); err != nil {
+	if err := s.Cache.Publish(ctx, msg); err != nil {
 		return fmt.Errorf("fail to publish cache block: %w", err)
 	}
 	l.WithField("timestamp", time.Now().String()).Debug("published")
 	timer2.ObserveDuration()
 
-	s.m.PublishSize.WithLabelValues("publishBlockCache").Observe(float64(len(b)))
-	s.m.PublishCounter.WithLabelValues("publishBlockCache").Add(float64(len(b)))
+	// s.m.PublishSize.WithLabelValues("publishBlockCache").Observe(float64(len(b)))
+	// s.m.PublishCounter.WithLabelValues("publishBlockCache").Add(float64(len(b)))
 
 	timer0.ObserveDuration()
 	return nil
@@ -299,109 +302,58 @@ func (s *Client) PublishSlotDelivered(ctx context.Context, slot structs.Slot) er
 	return nil // TODO
 }
 
-func (s *Client) encode(data any, fvf ForkVersionFormat) ([]byte, error) {
+func (s *Client) encode(data any, fvf transport.ForkVersionFormat) (transport.Message, error) {
 	var (
 		rawData []byte
 		err     error
 	)
 
-	if fvf == CapellaSSZ {
+	if fvf == transport.CapellaSSZ {
 		enc, ok := data.(EncoderSSZ)
 		if !ok {
-			return nil, errors.New("unable to cast to SSZ encoder")
+			return transport.Message{}, errors.New("unable to cast to SSZ encoder")
 		}
 		rawData, err = enc.MarshalSSZ()
 		if err != nil {
-			return nil, err
+			return transport.Message{}, err
 		}
 	} else {
 		rawData, err = json.Marshal(data)
 		if err != nil {
-			return nil, err
+			return transport.Message{}, err
 		}
 	}
 
-	item := JsonItem{
-		StreamData: rawData,
-		StreamMeta: Metadata{Source: s.Config.ID, ForkEncoding: fvf},
-	}
-
-	rawItem, err := json.Marshal(item)
-	if err != nil {
-		return nil, err
-	}
-	// encode the varint with a variable size
-	varintBytes := make([]byte, binary.MaxVarintLen64)
-	n := binary.PutUvarint(varintBytes, uint64(CapellaJson))
-	varintBytes = varintBytes[:n]
-
-	// append the varint
-	return append(varintBytes, rawItem...), nil
+	return transport.Message{
+		Payload:      rawData,
+		ForkEncoding: fvf, // NOTE:  Source set by Publish
+	}, nil
 }
 
-type StreamData interface {
-	Data() []byte
-	Meta() Metadata
-}
-
-func (s *Client) decode(b []byte) (StreamData, error) {
-	varint, n := binary.Uvarint(b)
-	if n <= 0 {
-		return nil, ErrDecodeVarint
-	}
-
-	b = b[n:]
-	forkEncoding := ForkVersionFormat(varint)
-
-	switch forkEncoding {
-	case BellatrixJson:
-		fallthrough
-	case CapellaJson:
-		var jsonReq JsonItem
-		if err := json.Unmarshal(b, &jsonReq); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal json stream data: %w", err)
-		}
-		return &jsonReq, nil
-	}
-	return nil, fmt.Errorf("invalid fork version format: %d", forkEncoding)
-}
-
-type ForkVersionFormat uint64
-
-const (
-	Unknown ForkVersionFormat = iota
-	AltairJson
-	BellatrixJson
-	CapellaJson
-	CapellaSSZ
-)
-
-var (
-	ErrDecodeVarint = errors.New("error decoding varint value")
-)
-
-func toBidFormat(fork structs.ForkVersion) ForkVersionFormat {
+func toBidFormat(fork structs.ForkVersion) transport.ForkVersionFormat {
 	switch fork {
 	case structs.ForkAltair:
-		return AltairJson
+		return transport.AltairJson
 	case structs.ForkBellatrix:
-		return BellatrixJson
+		return transport.BellatrixJson
 	case structs.ForkCapella:
-		return CapellaSSZ
+		return transport.CapellaSSZ
+	default:
+		return transport.Unknown
 	}
-	return Unknown
 }
 
-func toBlockCacheFormat(fork structs.ForkVersion) ForkVersionFormat {
+func toBlockCacheFormat(fork structs.ForkVersion) transport.ForkVersionFormat {
 	switch fork {
 	case structs.ForkAltair:
-		return AltairJson
+		return transport.AltairJson
 	case structs.ForkBellatrix:
-		return BellatrixJson
+		return transport.BellatrixJson
 	case structs.ForkCapella:
-		return CapellaSSZ
+		return transport.CapellaSSZ
+	default:
+		return transport.Unknown
 	}
-	return Unknown
 }
 
 type EncoderSSZ interface {

--- a/stream/structs.go
+++ b/stream/structs.go
@@ -6,24 +6,6 @@ import (
 	"github.com/blocknative/dreamboat/structs/forks/capella"
 )
 
-type Metadata struct {
-	Source       string
-	ForkEncoding ForkVersionFormat
-}
-
-type JsonItem struct {
-	StreamMeta Metadata
-	StreamData []byte
-}
-
-func (d JsonItem) Data() []byte {
-	return d.StreamData
-}
-
-func (d JsonItem) Meta() Metadata {
-	return d.StreamMeta
-}
-
 type HeaderWithSlot struct {
 	ExecutionPayloadHeader structs.ExecutionPayloadHeader
 	HeaderSlot             uint64

--- a/stream/transport/redis/redis.go
+++ b/stream/transport/redis/redis.go
@@ -2,42 +2,85 @@ package stream
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"time"
 
+	"github.com/blocknative/dreamboat/stream/transport"
+	"github.com/google/uuid"
+	"github.com/jpillora/backoff"
 	"github.com/lthibault/log"
 	"github.com/redis/go-redis/v9"
 )
 
-type Pubsub struct {
-	Redis  *redis.Client
-	Logger log.Logger
+type Topic struct {
+	Redis     *redis.Client
+	Logger    log.Logger
+	Name      string
+	LocalNode uuid.UUID
 }
 
-func (r *Pubsub) Publish(ctx context.Context, topic string, data []byte) error {
-	return r.Redis.Publish(ctx, topic, data).Err()
+func (t *Topic) Publish(ctx context.Context, m transport.Message) error {
+	m.Source = t.LocalNode
+
+	b, err := json.Marshal(&m)
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+
+	return t.Redis.Publish(ctx, t.Name, b).Err()
 }
 
-func (r *Pubsub) Subscribe(ctx context.Context, topic string) chan []byte {
-	logger := r.Logger.WithField("topic", topic)
+func (t *Topic) Subscribe(ctx context.Context) transport.Subscription {
+	return Subscription{
+		PubSub:    t.Redis.Subscribe(ctx, t.Name),
+		LocalNode: t.LocalNode,
+	}
+}
 
-	sub := make(chan []byte)
-	go func() {
-		defer close(sub)
-		for ctx.Err() == nil { // restart on failure
-			pubsub := r.Redis.Subscribe(ctx, topic)
-			logger.Debug("redis subscription started")
+type Subscription struct {
+	*redis.PubSub
+	Logger    log.Logger
+	LocalNode uuid.UUID
+}
 
-			redisSub := pubsub.Channel()
-			for data := range redisSub {
-				select {
-				case sub <- []byte(data.Payload):
-				case <-ctx.Done():
-					return
-				}
-			}
-			logger.Warn("redis subscription closed")
+func (s Subscription) Next(ctx context.Context) (transport.Message, error) {
+	var b = backoff.Backoff{
+		Min:    time.Millisecond,
+		Max:    time.Millisecond * 100,
+		Jitter: true,
+	}
+
+	for {
+		rawMsg, err := s.ReceiveMessage(ctx)
+		switch err {
+		case redis.ErrClosed, context.Canceled:
+			return transport.Message{}, err
 		}
 
-	}()
+		if err != nil {
+			s.Logger.
+				WithError(err).
+				WithField("attempt", b.Attempt()).
+				WithField("backoff", b.ForAttempt(b.Attempt())).
+				Warn("failed to get subscription message from redis")
+			time.Sleep(b.Duration())
+			continue
+		}
 
-	return sub
+		b.Reset()
+
+		msg, err := transport.Decode([]byte(rawMsg.Payload))
+		if err != nil {
+			s.Logger.
+				WithError(err).
+				Error("failed to decode subscription message from redis")
+			continue
+		}
+
+		// skip the message if we originally published it
+		if msg.Source != s.LocalNode {
+			return msg, nil
+		}
+	}
 }

--- a/stream/transport/transport.go
+++ b/stream/transport/transport.go
@@ -1,0 +1,71 @@
+package transport
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+const (
+	Unknown = iota
+	AltairJson
+	BellatrixJson
+	CapellaJson
+	CapellaSSZ
+)
+
+var (
+	ErrDecodeVarint = errors.New("error decoding varint value")
+)
+
+type Subscription interface {
+	Next(context.Context) (Message, error)
+	Close() error
+}
+
+type ForkVersionFormat uint64
+
+type Message struct {
+	Source       uuid.UUID
+	ForkEncoding ForkVersionFormat
+	Payload      []byte
+}
+
+func Encode(m Message) ([]byte, error) {
+	rawItem, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	// encode the varint with a variable size
+	varintBytes := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(varintBytes, CapellaJson)
+	varintBytes = varintBytes[:n]
+
+	// append the varint
+	return append(varintBytes, rawItem...), nil
+}
+
+func Decode(b []byte) (Message, error) {
+	varint, n := binary.Uvarint(b)
+	if n <= 0 {
+		return Message{}, ErrDecodeVarint
+	}
+
+	b = b[n:]
+
+	switch ForkVersionFormat(varint) {
+	case BellatrixJson, CapellaJson:
+		var msg Message
+		if err := json.Unmarshal(b, &msg); err != nil {
+			return Message{}, err
+		}
+		return msg, nil
+
+	default:
+		return Message{}, fmt.Errorf("invalid fork version: %d", varint)
+	}
+}


### PR DESCRIPTION
This PR refactors `stream.Client` in preparation for Wetware-backed pubsub.  There are no functional changes.

- `stream.Client` is no longer responsible for (un)marshaling the message envelope that is sent to Redis.  This is now the responsibility of the `stream.PubSub` implementation.  A new `stream/transport` package has been created to provide a common envelope implementation called `Message`, and to handle its (de)serialization.
- `stream.Client` is no longer responsible for filtering messages that originate from the local node.  This is now the responsibility of the `stream.PubSub` implementation.
- `stream.PubSub`'s `Subscribe()` method now returns a `transport.Subscriber` interface.  This decoupling makes it easier to perform the aforementioned filtering.  In the near future, it will also facilitate the writing of a Wetware based implementation.
- Instantiation and lifecycle management of `stream.Client` is simplified.  In particular, redundant queues are elided and setup is performed through lazy initialization via `sync.Once`.

@lukanus Apologies for the big commit (141e042e48db9c07a10946319874a88ddd107be6).  Should be tighter from here on out.