### PR TITLE
Debug block gas usage

### DIFF
--- a/relay/submit.go
+++ b/relay/submit.go
@@ -80,7 +80,7 @@ func (rs *Relay) SubmitBlock(ctx context.Context, m *structs.MetricGroup, uc str
 	m.AppendSince(tVerify, "submitBlock", "verify")
 
 	root, wRetried, err := verifyWithdrawals(rs.beaconState, sbr)
-	logger = logger.WithField("withdrawalsRoot", root)
+	logger = logger.With(log.F{"withdrawalsRoot": root, "registeredGasLimit": gasLimit})
 	if err != nil {
 		return fmt.Errorf("failed to verify withdrawals: %w", err)
 	}

--- a/relay/submit.go
+++ b/relay/submit.go
@@ -89,6 +89,7 @@ func (rs *Relay) SubmitBlock(ctx context.Context, m *structs.MetricGroup, uc str
 	select {
 	case err := <-valErr:
 		if err != nil {
+			logger.WithError(err).Debug("block validation failure")
 			return err
 		}
 	case <-ctx.Done():


### PR DESCRIPTION
# What 🕵️‍♀️
- Add  `registeredGasLimit` field to the logger in `SubmitBlock`

# Why 🔑
Help us understand why some blocks fail validation because of an incorrect gas limit 

# Testing 🧪
- [ ] `go test -race ./...` from root
